### PR TITLE
Append options for disabling custom converters on net6

### DIFF
--- a/ATI.Services.Common/Serializers/SerializerFactory.cs
+++ b/ATI.Services.Common/Serializers/SerializerFactory.cs
@@ -12,7 +12,7 @@ namespace ATI.Services.Common.Serializers
             {
                 SerializerType.Newtonsoft => new NewtonsoftSerializer(),
                 SerializerType.SystemTextJson => new SystemTextJsonSerializer(),
-                SerializerType.SystemTextJsonClassic => new SystemTextJsonSerializer(true),
+                SerializerType.SystemTextJsonClassic => new SystemTextJsonSerializer(false),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
             };
         }

--- a/ATI.Services.Common/Serializers/SerializerFactory.cs
+++ b/ATI.Services.Common/Serializers/SerializerFactory.cs
@@ -12,6 +12,7 @@ namespace ATI.Services.Common.Serializers
             {
                 SerializerType.Newtonsoft => new NewtonsoftSerializer(),
                 SerializerType.SystemTextJson => new SystemTextJsonSerializer(),
+                SerializerType.SystemTextJsonClassic => new SystemTextJsonSerializer(true),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
             };
         }

--- a/ATI.Services.Common/Serializers/SerializerType.cs
+++ b/ATI.Services.Common/Serializers/SerializerType.cs
@@ -3,6 +3,11 @@ namespace ATI.Services.Common.Serializers
     public enum SerializerType
     {
         Newtonsoft = 0,
-        SystemTextJson = 1
+        SystemTextJson = 1,
+        
+        /// <summary>
+        /// System.Text.Json with disabled converters. Since net6.0  
+        /// </summary>
+        SystemTextJsonClassic = 2
     }
 }

--- a/ATI.Services.Common/Serializers/SystemTextJsonSerialization/SystemTextJsonSerializer.cs
+++ b/ATI.Services.Common/Serializers/SystemTextJsonSerialization/SystemTextJsonSerializer.cs
@@ -9,18 +9,17 @@ namespace ATI.Services.Common.Serializers.SystemTextJsonSerialization
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 
-        public SystemTextJsonSerializer(bool disableConverters = false)
+        public SystemTextJsonSerializer(bool enableCustomConverters = true)
         {
-            _jsonSerializerOptions = disableConverters
-                ? new JsonSerializerOptions()
-                : new JsonSerializerOptions
+            _jsonSerializerOptions = enableCustomConverters
+                ? new JsonSerializerOptions
                 {
                     Converters =
                     {
                         new TimeSpanConverter(),
                         new DictionaryKeyValueConverter()
                     }
-                };
+                } : new JsonSerializerOptions();
         }
 
         public SystemTextJsonSerializer(JsonSerializerOptions serializerOptions)

--- a/ATI.Services.Common/Serializers/SystemTextJsonSerialization/SystemTextJsonSerializer.cs
+++ b/ATI.Services.Common/Serializers/SystemTextJsonSerialization/SystemTextJsonSerializer.cs
@@ -9,16 +9,18 @@ namespace ATI.Services.Common.Serializers.SystemTextJsonSerialization
     {
         private JsonSerializerOptions _jsonSerializerOptions;
 
-        public SystemTextJsonSerializer()
+        public SystemTextJsonSerializer(bool disableConverters = false)
         {
-            _jsonSerializerOptions = new JsonSerializerOptions
-            {
-                Converters =
+            _jsonSerializerOptions = !disableConverters
+                ? new JsonSerializerOptions
                 {
-                    new TimeSpanConverter(),
-                    new DictionaryKeyValueConverter()
+                    Converters =
+                    {
+                        new TimeSpanConverter(),
+                        new DictionaryKeyValueConverter()
+                    }
                 }
-            };
+                : new JsonSerializerOptions();
         }
 
         public SystemTextJsonSerializer(JsonSerializerOptions serializerOptions)

--- a/ATI.Services.Common/Serializers/SystemTextJsonSerialization/SystemTextJsonSerializer.cs
+++ b/ATI.Services.Common/Serializers/SystemTextJsonSerialization/SystemTextJsonSerializer.cs
@@ -11,16 +11,16 @@ namespace ATI.Services.Common.Serializers.SystemTextJsonSerialization
 
         public SystemTextJsonSerializer(bool disableConverters = false)
         {
-            _jsonSerializerOptions = !disableConverters
-                ? new JsonSerializerOptions
+            _jsonSerializerOptions = disableConverters
+                ? new JsonSerializerOptions()
+                : new JsonSerializerOptions
                 {
                     Converters =
                     {
                         new TimeSpanConverter(),
                         new DictionaryKeyValueConverter()
                     }
-                }
-                : new JsonSerializerOptions();
+                };
         }
 
         public SystemTextJsonSerializer(JsonSerializerOptions serializerOptions)


### PR DESCRIPTION
Начиная с net6 нет потребности в кастомных конверторах для словаря и timespan для System.Text.Json. Существующие конверторы создают проблемы. Добавляем в фабрику возможность выбрать сериализатор без доп опций.