### PR TITLE
Nullable lables in swagger

### DIFF
--- a/ATI.Services.Common/Behaviors/CommonBehavior.cs
+++ b/ATI.Services.Common/Behaviors/CommonBehavior.cs
@@ -239,7 +239,7 @@ namespace ATI.Services.Common.Behaviors
                 case ActionStatus.NotFound:
                 case ActionStatus.NoContent:
                     if (resultIsArray)
-                        return new OkObjectResult(EmptyArray);
+                        return new JsonResult(EmptyArray);
                     break;
             }
 
@@ -268,7 +268,7 @@ namespace ATI.Services.Common.Behaviors
                 case ActionStatus.NotFound:
                 case ActionStatus.NoContent:
                     if (resultIsArray)
-                        return new OkObjectResult(EmptyArray);
+                        return new JsonResult(EmptyArray);
                     break;
             }
 
@@ -316,7 +316,7 @@ namespace ATI.Services.Common.Behaviors
         }
 
         private static readonly IActionResult OkResult = new OkResult();
-        private static readonly IActionResult OkResultWithEmptyArray = new OkObjectResult(EmptyArray);
+        private static readonly IActionResult OkResultWithEmptyArray = new JsonResult(EmptyArray);
         
         internal static IActionResult GetActionResult<T>(ActionStatus status, bool isInternal, string reason = null,
             Func<ActionStatus, HttpStatusCode?> customStatusFunc = null,

--- a/ATI.Services.Common/Swagger/SwaggerExtensions.cs
+++ b/ATI.Services.Common/Swagger/SwaggerExtensions.cs
@@ -110,11 +110,12 @@ namespace ATI.Services.Common.Swagger
             
             app.UseSwagger(c =>
             {
-                c.SerializeAsV2 = true;
                 customSwaggerOptions?.Invoke(c);
             });
             app.UseSwaggerUI(c =>
             {
+                c.EnableDeepLinking();
+                c.DisplayOperationId();
                 foreach (var tag in Enum.GetNames(typeof(SwaggerTag)))
                 {
                     c.SwaggerEndpoint($"/swagger/{tag}/swagger.json", $"{swaggerOptions.ServiceName} {tag} API");


### PR DESCRIPTION
- enables swagger v3
- adds block anchors to url(allows to share link to specific block in swagger ui)
- fixes bug: 500 status code when trying serilize OkObjectResult response in endpoint that has `[Produce("application/json")]` attribute and `.WithNotFoundCondition(...)`

How to reproduce bug:
1. Create endpoint as in expample below.
2. Produce big rps to this endpoint(at least 50 in parallel threads).
I used tool [hey](https://github.com/rakyll/hey) `hey_windows_amd64_2.exe -c 10 -q 50 -n 1000 -m GET -H "Accept-Language: ru" -H "X-Client-Name: TestAidar" http://localhost/_internal/test`
3. This will cause error ` Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor[1] No output formatter was found for content types 'application/json' to write the response.` (this by default is hidden by `.UseCustomExceptionHandler` in staging and prod)

```csharp
[Produces("application/json")]  // defines content-type header in response
[HttpGet("_internal/test")]
public IActionResult Test()
{
    return new OperationResult<List<FirmComment>>(new List<FirmComment>())  //array return type
           .AsActionBuilder()
           .WithNotFoundCondition(x => x.Count == 0)  //in case of array notFound returns OkObjectResult(new T[0])
           .Execute();
}
```