### PR TITLE
Possibility to log timeouts as Warnings

### DIFF
--- a/ATI.Services.Common/Behaviors/OperationBuilder/Extensions/ActionBuilderExtensions.cs
+++ b/ATI.Services.Common/Behaviors/OperationBuilder/Extensions/ActionBuilderExtensions.cs
@@ -15,10 +15,7 @@ namespace ATI.Services.Common.Behaviors.OperationBuilder.Extensions
             return new(operation);
         }
 
-        public static ActionBuilder AsActionBuilder(this OperationResult operation)
-        {
-            return new(operation);
-        }
+        public static ActionBuilder AsActionBuilder(this OperationResult operation) => new(operation);
 
         public static async Task<IActionResult> AsActionResultAsync(this Task<OperationResult> operationTask, bool? internalFlag = false)
         {
@@ -28,7 +25,7 @@ namespace ATI.Services.Common.Behaviors.OperationBuilder.Extensions
                 actionBuilder.WithInternalFlag(internalFlag.Value);
             }
 
-            return await new ActionBuilder(operationTask).ExecuteAsync();
+            return await actionBuilder.ExecuteAsync();
         }
 
         public static IActionResult AsActionResult(this OperationResult operation, bool? internalFlag = false)

--- a/ATI.Services.Common/Logging/LoggerExtension.cs
+++ b/ATI.Services.Common/Logging/LoggerExtension.cs
@@ -30,6 +30,11 @@ public static class LoggerExtension
         logger.LogWithObject(LogLevel.Warn, null, message, null, logObjects);
     }
     
+    public static void WarnWithObject(this ILogger logger, Exception ex, params object[] logObjects)
+    {
+        logger.LogWithObject(LogLevel.Warn, ex, logObjects: logObjects);
+    }
+    
     public static void LogWithObject(this ILogger logger,
         LogLevel logLevel,
         Exception ex = null,

--- a/ATI.Services.Common/Options/BaseServiceOptions.cs
+++ b/ATI.Services.Common/Options/BaseServiceOptions.cs
@@ -10,6 +10,7 @@ public class BaseServiceOptions
 {
     public string ConsulName { get; set; }
     public TimeSpan TimeOut { get; set; }
+    public bool LogTimeoutsAsWarn { get; set; }
     public string Environment { get; set; }
     public TimeSpan? LongRequestTime { get; set; }
 

--- a/ATI.Services.Common/Tracing/TracedHttpClientConfig.cs
+++ b/ATI.Services.Common/Tracing/TracedHttpClientConfig.cs
@@ -33,6 +33,7 @@ namespace ATI.Services.Common.Tracing
         
         public Dictionary<string, string> Headers { get; set; } = new();
         public List<string> HeadersToProxy { get; set; } = new();
+        public bool LogTimeoutsAsWarn { get; set; }
 
         private void SetSerializer(
             SerializerType serializerType,


### PR DESCRIPTION
- now timeouts in `ConsulMetricsHttpClientWrapper` and `TracingHttpClientWrapper` will return `ActionStatus.Timeout`
- new parameter `LogTimeoutsAsWarn` in BaseServiceOptions.cs, 
it allows all timeouts to be logged as Warn(`false` by default) instead of Error