### PR TITLE
Log to logContext http-response body of request with bad status code

### DIFF
--- a/ATI.Services.Common/Logging/NLogConfigurator.cs
+++ b/ATI.Services.Common/Logging/NLogConfigurator.cs
@@ -32,7 +32,8 @@ namespace ATI.Services.Common.Logging
             JsonAttributeHelper.CreateWithoutUnicodeEscaping("exceptionPretty", "${onexception:${exception:format=ToString,Data:exceptionDataSeparator=\\r\\n}}"),
             JsonAttributeHelper.CreateWithoutUnicodeEscaping("logContext", "${event-properties:logContext}"),
             JsonAttributeHelper.CreateWithoutUnicodeEscaping("metricString", "${event-properties:metricString}"),
-            JsonAttributeHelper.CreateWithoutUnicodeEscaping("metricSource", "${event-properties:metricSource}")
+            JsonAttributeHelper.CreateWithoutUnicodeEscaping("metricSource", "${event-properties:metricSource}"),
+            JsonAttributeHelper.CreateWithoutUnicodeEscaping("responseBody", "${event-properties:responseBody}")
         };
 
         public NLogConfigurator(NLogOptions options)

--- a/ATI.Services.Common/Logging/NLogConfigurator.cs
+++ b/ATI.Services.Common/Logging/NLogConfigurator.cs
@@ -32,8 +32,7 @@ namespace ATI.Services.Common.Logging
             JsonAttributeHelper.CreateWithoutUnicodeEscaping("exceptionPretty", "${onexception:${exception:format=ToString,Data:exceptionDataSeparator=\\r\\n}}"),
             JsonAttributeHelper.CreateWithoutUnicodeEscaping("logContext", "${event-properties:logContext}"),
             JsonAttributeHelper.CreateWithoutUnicodeEscaping("metricString", "${event-properties:metricString}"),
-            JsonAttributeHelper.CreateWithoutUnicodeEscaping("metricSource", "${event-properties:metricSource}"),
-            JsonAttributeHelper.CreateWithoutUnicodeEscaping("responseBody", "${event-properties:responseBody}")
+            JsonAttributeHelper.CreateWithoutUnicodeEscaping("metricSource", "${event-properties:metricSource}")
         };
 
         public NLogConfigurator(NLogOptions options)

--- a/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
+++ b/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
@@ -321,20 +321,16 @@ namespace ATI.Services.Common.Tracing
                     {
                         var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
                             message.FullUri, responseMessage.StatusCode);
-                        var additionalLogProperties = new Dictionary<object, object>
-                        {
-                            { "responseBody", responseContent }
-                        };
 
                         if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                         {
-                            _logger.LogWithObject(_logLevelOverride(LogLevel.Error), 
-                                additionalProperties: additionalLogProperties, logObjects: logMessage);
+                            _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
+                                logObjects: new { ResponseBody = responseContent });
                         }
                         else
                         {
                             _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                                additionalLogProperties);
+                                logObjects: new { ResponseBody = responseContent });
                         }
                     }
 
@@ -414,20 +410,16 @@ namespace ATI.Services.Common.Tracing
                     var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
                         message.FullUri, responseMessage.StatusCode);
                     var responseContent = await responseMessage.Content.ReadAsStringAsync();
-                    var additionalLogProperties = new Dictionary<object, object>
-                    {
-                        { "responseBody", responseContent }
-                    };
-                    
+
                     if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                            additionalLogProperties);
+                            logObjects: new { ResponseBody = responseContent });
                     }
                     else
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                            additionalLogProperties);
+                            logObjects: new { ResponseBody = responseContent });
                     }
                     
                     return new OperationResult<TResult>(
@@ -470,20 +462,16 @@ namespace ATI.Services.Common.Tracing
 
                     var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
                         message.FullUri, responseMessage.StatusCode);
-                    var additionalLogProperties = new Dictionary<object, object>
-                    {
-                        { "responseBody", responseContent }
-                    };
-                        
+
                     if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                            additionalLogProperties);
+                            logObjects: new { ResponseBody = responseContent });
                     }
                     else
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                            additionalLogProperties);
+                            logObjects: new { ResponseBody = responseContent });
                     }
 
                     return new OperationResult<string>(responseContent,

--- a/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
+++ b/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
@@ -325,12 +325,12 @@ namespace ATI.Services.Common.Tracing
                         if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                         {
                             _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                                logObjects: new { ResponseBody = responseContent });
+                                logObjects: responseContent);
                         }
                         else
                         {
                             _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                                logObjects: new { ResponseBody = responseContent });
+                                logObjects: responseContent);
                         }
                     }
 
@@ -414,12 +414,12 @@ namespace ATI.Services.Common.Tracing
                     if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                            logObjects: new { ResponseBody = responseContent });
+                            logObjects: responseContent);
                     }
                     else
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                            logObjects: new { ResponseBody = responseContent });
+                            logObjects: responseContent);
                     }
                     
                     return new OperationResult<TResult>(
@@ -466,12 +466,12 @@ namespace ATI.Services.Common.Tracing
                     if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                            logObjects: new { ResponseBody = responseContent });
+                            logObjects: responseContent);
                     }
                     else
                     {
                         _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                            logObjects: new { ResponseBody = responseContent });
+                            logObjects: responseContent);
                     }
 
                     return new OperationResult<string>(responseContent,

--- a/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
+++ b/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
@@ -402,14 +402,15 @@ namespace ATI.Services.Common.Tracing
                     }
 
                     var logMessage = $"Сервис:{Config.ServiceName} в ответ на запрос [HTTP {message.Method} {message.FullUri}] вернул ответ с статус кодом {responseMessage.StatusCode}.";
+                    var responseSting = await responseMessage.Content.ReadAsStringAsync();
 
                     if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                     {
-                        _logger.Log(_logLevelOverride(LogLevel.Error), logMessage);
+                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage, logObjects: responseSting);
                     }
                     else
                     {
-                        _logger.Log(_logLevelOverride(LogLevel.Warn), logMessage);
+                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage, logObjects: responseSting);
                     }
                     
                     return new OperationResult<TResult>(

--- a/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
+++ b/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
@@ -322,16 +322,10 @@ namespace ATI.Services.Common.Tracing
                         var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
                             message.FullUri, responseMessage.StatusCode);
 
-                        if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
-                        {
-                            _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                                logObjects: responseContent);
-                        }
-                        else
-                        {
-                            _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                                logObjects: responseContent);
-                        }
+                        var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
+                            ? _logLevelOverride(LogLevel.Error)
+                            : _logLevelOverride(LogLevel.Warn);
+                        _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
                     }
 
                     var result = new HttpResponseMessage<TResult>
@@ -411,17 +405,11 @@ namespace ATI.Services.Common.Tracing
                         message.FullUri, responseMessage.StatusCode);
                     var responseContent = await responseMessage.Content.ReadAsStringAsync();
 
-                    if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
-                    {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                            logObjects: responseContent);
-                    }
-                    else
-                    {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                            logObjects: responseContent);
-                    }
-                    
+                    var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
+                        ? _logLevelOverride(LogLevel.Error)
+                        : _logLevelOverride(LogLevel.Warn);
+                    _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
+
                     return new OperationResult<TResult>(
                         OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
                 }
@@ -463,16 +451,10 @@ namespace ATI.Services.Common.Tracing
                     var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
                         message.FullUri, responseMessage.StatusCode);
 
-                    if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
-                    {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
-                            logObjects: responseContent);
-                    }
-                    else
-                    {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
-                            logObjects: responseContent);
-                    }
+                    var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
+                        ? _logLevelOverride(LogLevel.Error)
+                        : _logLevelOverride(LogLevel.Warn);
+                    _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
 
                     return new OperationResult<string>(responseContent,
                         OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));

--- a/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
+++ b/ATI.Services.Common/Tracing/TracingHttpClientWrapper.cs
@@ -29,6 +29,8 @@ namespace ATI.Services.Common.Tracing
         private readonly MetricsTracingFactory _metricsTracingFactory;
         private readonly Func<LogLevel, LogLevel> _logLevelOverride;
 
+        private const string LogMessageTemplate =
+            "Сервис:{0} в ответ на запрос [HTTP {1} {2}] вернул ответ с статус кодом {3}.";
 
         public TracingHttpClientWrapper(TracedHttpClientConfig config)
         {
@@ -313,18 +315,26 @@ namespace ATI.Services.Common.Tracing
                     using var requestMessage = message.ToRequestMessage(Config);
 
                     using var responseMessage = await _httpClient.SendAsync(requestMessage);
+                    var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                     if (!responseMessage.IsSuccessStatusCode)
                     {
-                        var logMessage = $"Сервис:{Config.ServiceName} в ответ на запрос [HTTP {message.Method} {message.FullUri}] вернул ответ с статус кодом {responseMessage.StatusCode}.";
+                        var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
+                            message.FullUri, responseMessage.StatusCode);
+                        var additionalLogProperties = new Dictionary<object, object>
+                        {
+                            { "responseBody", responseContent }
+                        };
 
                         if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                         {
-                            _logger.LogWithObject(_logLevelOverride(LogLevel.Error), logObjects: logMessage);
+                            _logger.LogWithObject(_logLevelOverride(LogLevel.Error), 
+                                additionalProperties: additionalLogProperties, logObjects: logMessage);
                         }
                         else
                         {
-                            _logger.Log(_logLevelOverride(LogLevel.Warn), logMessage);
+                            _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
+                                additionalLogProperties);
                         }
                     }
 
@@ -335,7 +345,7 @@ namespace ATI.Services.Common.Tracing
                         TrailingHeaders = responseMessage.TrailingHeaders,
                         ReasonPhrase = responseMessage.ReasonPhrase,
                         Version = responseMessage.Version,
-                        RawContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false)
+                        RawContent = responseContent
                     };
 
                     try
@@ -401,16 +411,23 @@ namespace ATI.Services.Common.Tracing
                         return new OperationResult<TResult>(result);
                     }
 
-                    var logMessage = $"Сервис:{Config.ServiceName} в ответ на запрос [HTTP {message.Method} {message.FullUri}] вернул ответ с статус кодом {responseMessage.StatusCode}.";
-                    var responseSting = await responseMessage.Content.ReadAsStringAsync();
-
+                    var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
+                        message.FullUri, responseMessage.StatusCode);
+                    var responseContent = await responseMessage.Content.ReadAsStringAsync();
+                    var additionalLogProperties = new Dictionary<object, object>
+                    {
+                        { "responseBody", responseContent }
+                    };
+                    
                     if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
                     {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage, logObjects: responseSting);
+                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
+                            additionalLogProperties);
                     }
                     else
                     {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage, logObjects: responseSting);
+                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
+                            additionalLogProperties);
                     }
                     
                     return new OperationResult<TResult>(
@@ -447,6 +464,27 @@ namespace ATI.Services.Common.Tracing
 
                     using var responseMessage = await _httpClient.SendAsync(requestMessage);
                     var responseContent = await responseMessage.Content.ReadAsStringAsync();
+
+                    if (responseMessage.IsSuccessStatusCode)
+                        return new OperationResult<string>(responseContent);
+
+                    var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
+                        message.FullUri, responseMessage.StatusCode);
+                    var additionalLogProperties = new Dictionary<object, object>
+                    {
+                        { "responseBody", responseContent }
+                    };
+                        
+                    if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
+                    {
+                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error), ex: null, logMessage,
+                            additionalLogProperties);
+                    }
+                    else
+                    {
+                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn), ex: null, logMessage,
+                            additionalLogProperties);
+                    }
 
                     return new OperationResult<string>(responseContent,
                         OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));


### PR DESCRIPTION
In the `TracingHttpClientWrapper` class were made next changes:
- now for every http request finished with bad status code a log message in the `logContext` property contains it's response body. 
- now the method `public async Task<OperationResult<HttpResponseMessage<TResult>>> SendAsync(Uri fullUri, string metricName, TModel model, ...)` writes log message to `message` property instead of the `logContext` property.
- now the method `private async Task<OperationResult<string>> SendAsync(string methodName, HttpMessage message)` logs every respons with bad status code like in other methods of the class. 