### PR TITLE
Send context in the end of MetricsStatusCodeCounterMiddleware

### DIFF
--- a/ATI.Services.Common/Metrics/MetricsStatusCodeCounterMiddleware.cs
+++ b/ATI.Services.Common/Metrics/MetricsStatusCodeCounterMiddleware.cs
@@ -23,10 +23,10 @@ namespace ATI.Services.Common.Metrics
 
         public async Task InvokeAsync(HttpContext context)
         {
-            await _next(context);
             var param = new[] {context.Response.StatusCode.ToString()}.Concat(AppHttpContext.MetricsHeadersValues)
                 .ToArray();
             counter.WithLabels(param).Inc();
+            await _next(context);
         }
     }
 }


### PR DESCRIPTION
try fix
1) Object reference not set to an instance of an object. 
2) Collection was modified; enumeration operation may not execute In MetricsStatusCodeCounterMiddleware