### PR TITLE
adding quantiles to summary

### DIFF
--- a/ATI.Services.Common/Metrics/MetricsFactory.cs
+++ b/ATI.Services.Common/Metrics/MetricsFactory.cs
@@ -18,6 +18,13 @@ namespace ATI.Services.Common.Metrics
         private readonly LogSource _logSource;
         private static TimeSpan _defaultLongRequestTime = TimeSpan.FromSeconds(1);
 
+        private static readonly QuantileEpsilonPair[] _summaryQuantileEpsilonPairs = {
+            new(0.5, 0.05),
+            new(0.9, 0.05),
+            new(0.95, 0.01),
+            new(0.99, 0.005),
+        };
+
         //Время запроса считающегося достаточно долгим, что бы об этом доложить в кибану
         private readonly TimeSpan _longRequestTime;
 
@@ -163,7 +170,8 @@ namespace ATI.Services.Common.Metrics
             {
                 var options = new SummaryConfiguration
                 {
-                    MaxAge = TimeSpan.FromMinutes(1)
+                    MaxAge = TimeSpan.FromMinutes(1),
+                    Objectives = _summaryQuantileEpsilonPairs
                 };
 
                 Summary = Prometheus.Metrics.CreateSummary(
@@ -187,7 +195,8 @@ namespace ATI.Services.Common.Metrics
             {
                 var options = new SummaryConfiguration
                 {
-                    MaxAge = TimeSpan.FromMinutes(1)
+                    MaxAge = TimeSpan.FromMinutes(1),
+                    Objectives = _summaryQuantileEpsilonPairs
                 };
 
                 Summary = Prometheus.Metrics.CreateSummary(


### PR DESCRIPTION
Quantilies added to Summary metric creation like in [prometheus .net example](https://github.com/prometheus-net/prometheus-net#summary):
```csharp
Objectives = new[]
            {
                new QuantileEpsilonPair(0.5, 0.05),
                new QuantileEpsilonPair(0.9, 0.05),
                new QuantileEpsilonPair(0.95, 0.01),
                new QuantileEpsilonPair(0.99, 0.005),
            }
```
Them were lost during prometheus .net library [update from v2 to v3](https://github.com/prometheus-net/prometheus-net/compare/v2.1.3...v3.0.0#diff-77565104273ca852503ad12bcb5f5f23d37b69a8de6721f671746ac2854e7bf1).
