### PR TITLE
Fix locale parsing

### DIFF
--- a/ATI.Services.Common/Localization/LocaleHelper.cs
+++ b/ATI.Services.Common/Localization/LocaleHelper.cs
@@ -33,8 +33,7 @@ namespace ATI.Services.Common.Localization
                 var language =
                     acceptLanguage.Split(',')
                         .Select(StringWithQualityHeaderValue.Parse)
-                        .Where(lang =>
-                            ServiceVariables.SupportedLocales.Contains(lang.Value, StringComparer.OrdinalIgnoreCase))
+                        .Where(lang => ServiceVariables.SupportedLocales.Contains(lang.Value))
                         .MaxBy(lang => lang.Quality);
 
                 if (language == null) 

--- a/ATI.Services.Common/Localization/LocaleHelper.cs
+++ b/ATI.Services.Common/Localization/LocaleHelper.cs
@@ -36,11 +36,13 @@ namespace ATI.Services.Common.Localization
                         .Where(lang =>
                             ServiceVariables.SupportedLocales.Contains(lang.Value, StringComparer.OrdinalIgnoreCase))
                         .MaxBy(lang => lang.Quality);
+
+                if (language == null) 
+                    return false;
                 
-                if (language != null)
-                    cultureInfo = new CultureInfo(language.Value);
-                
+                cultureInfo = new CultureInfo(language.Value);
                 return true;
+
             }
             catch (Exception)
             {

--- a/ATI.Services.Common/Variables/ServiceVariablesInitializer.cs
+++ b/ATI.Services.Common/Variables/ServiceVariablesInitializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ATI.Services.Common.Initializers;
 using ATI.Services.Common.Initializers.Interfaces;
@@ -28,7 +29,8 @@ namespace ATI.Services.Common.Variables
             ServiceVariables.ServiceAsClientName = ServiceVariables.Variables.TryGetValue("ServiceAsClientName", out var name) ? name : "";
             ServiceVariables.ServiceAsClientHeaderName = ServiceVariables.Variables.TryGetValue("ServiceAsClientHeaderName", out var headerName) ? headerName : "";
             ServiceVariables.DefaultLocale = ServiceVariables.Variables.TryGetValue("DefaultLocale", out var locale) ? locale : "ru";
-            ServiceVariables.SupportedLocales = _options?.SupportedLocales ?? new HashSet<string>( new []{ServiceVariables.DefaultLocale} );
+            var locales = _options?.SupportedLocales ?? new List<string> { ServiceVariables.DefaultLocale };
+            ServiceVariables.SupportedLocales = new HashSet<string>(locales, StringComparer.OrdinalIgnoreCase);
 
             _initialized = true;
             return Task.CompletedTask;

--- a/ATI.Services.Common/Variables/ServiceVariablesOptions.cs
+++ b/ATI.Services.Common/Variables/ServiceVariablesOptions.cs
@@ -5,6 +5,6 @@ namespace ATI.Services.Common.Variables
     public class ServiceVariablesOptions
     {
         public Dictionary<string, string> Variables { get; set; }
-        public HashSet<string> SupportedLocales { get; set; }
+        public List<string> SupportedLocales { get; set; }
     }
 }


### PR DESCRIPTION
Bugfix:
- fixes exception that occurs in case of handling rmq message with unsupported locale(message will be lost), now it will be handled with default locale