### PR TITLE
Value is not Null when Success is true

### DIFF
--- a/ATI.Services.Common/Behaviors/OperationResult.cs
+++ b/ATI.Services.Common/Behaviors/OperationResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using JetBrains.Annotations;
@@ -146,6 +147,7 @@ namespace ATI.Services.Common.Behaviors
         /// <summary>
         /// Возвращает флаг, указывающий, успешно ли была выполнена операция и проверяет что значение не равно null        
         /// </summary>
+        [MemberNotNullWhen(returnValue: true, nameof(Value))]
         public new bool Success => ActionStatus == ActionStatus.Ok && Value != null &&
                                    (!UseCountSuccessCondition || !ValueIsArray || ((ICollection)Value).Count != 0);
 


### PR DESCRIPTION
`[MemberNotNullWhen]` attribute added for `OperationResult<T>.Success` property to specify that `Value` property has non-null value when `Success` returns `true`. It is helpful when nullable reference types are enabled in C# project