### PR TITLE
Header added using TryAddWithoutValidation in MetricsHttpClientWrapper

### DIFF
--- a/ATI.Services.Common/Behaviors/ActionStatus.cs
+++ b/ATI.Services.Common/Behaviors/ActionStatus.cs
@@ -80,6 +80,10 @@
         /// <summary>
         /// Превышено допустимая частота запросов
         /// </summary>
-        TooManyRequests = 20
+        TooManyRequests = 20,
+        /// <summary>
+        /// Документ не изменился с указанного момента
+        /// </summary>
+        NotModified = 21
     }
 }

--- a/ATI.Services.Common/Behaviors/OperationResult.cs
+++ b/ATI.Services.Common/Behaviors/OperationResult.cs
@@ -129,6 +129,8 @@ namespace ATI.Services.Common.Behaviors
                     return ActionStatus.Timeout;
                 case HttpStatusCode.TooManyRequests:
                     return ActionStatus.TooManyRequests;
+                case HttpStatusCode.NotModified:
+                    return ActionStatus.NotModified;
                 default:
                     return ActionStatus.InternalServerError;
             }

--- a/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
+++ b/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
@@ -530,12 +530,12 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
                     Headers.AddRange(AppHttpContext.HeadersAndValuesToProxy(config.HeadersToProxy));
 
                 foreach (var header in Headers)
-                    msg.Headers.Add(header.Key, header.Value);
+                    msg.Headers.TryAddWithoutValidation(header.Key, header.Value);
 
                 string acceptLanguage;
                 if (config.AddCultureToRequest
                     && (acceptLanguage = FlowContext<RequestMetaData>.Current.AcceptLanguage) != null)
-                    msg.Headers.TryAddWithoutValidation("Accept-Language", acceptLanguage);
+                    msg.Headers.Add("Accept-Language", acceptLanguage);
 
 
                 if (string.IsNullOrEmpty(Content) == false)

--- a/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
+++ b/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
@@ -378,7 +378,7 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
                             });
                     }
 
-                    return new OperationResult<HttpResponseMessage<TResult>>(result);
+                    return new(result, OperationResult.GetActionStatusByHttpStatusCode(result.StatusCode));
                 }
             }
             catch (Exception e)
@@ -408,7 +408,7 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
                     {
                         var stream = await responseMessage.Content.ReadAsStreamAsync();
                         var result = await Config.Serializer.DeserializeAsync<TResult>(stream);
-                        return new OperationResult<TResult>(result);
+                        return new OperationResult<TResult>(result, OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
                     }
 
                     var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
@@ -420,8 +420,7 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
                         : _logLevelOverride(LogLevel.Warn);
                     _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
 
-                    return new OperationResult<TResult>(
-                        OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
+                    return new OperationResult<TResult>(OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
                 }
                 catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
                 {
@@ -455,7 +454,7 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
                     var responseContent = await responseMessage.Content.ReadAsStringAsync();
 
                     if (responseMessage.IsSuccessStatusCode)
-                        return new OperationResult<string>(responseContent);
+                        return new OperationResult<string>(responseContent, OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
 
                     var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
                         message.FullUri, responseMessage.StatusCode);

--- a/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
+++ b/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
@@ -352,7 +352,9 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
 
                     try
                     {
-                        result.Content = Config.Serializer.Deserialize<TResult>(result.RawContent);
+                        result.Content = !string.IsNullOrEmpty(result.RawContent)
+                                             ? Config.Serializer.Deserialize<TResult>(result.RawContent)
+                                             : default;
                     }
                     catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
                     {

--- a/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
+++ b/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
@@ -535,7 +535,7 @@ namespace ATI.Services.Common.Metrics.HttpWrapper
                 string acceptLanguage;
                 if (config.AddCultureToRequest
                     && (acceptLanguage = FlowContext<RequestMetaData>.Current.AcceptLanguage) != null)
-                    msg.Headers.Add("Accept-Language", acceptLanguage);
+                    msg.Headers.TryAddWithoutValidation("Accept-Language", acceptLanguage);
 
 
                 if (string.IsNullOrEmpty(Content) == false)


### PR DESCRIPTION
Small changes allowing to use `ETag/If-None-Match` based requests
- headers will be added without validation in `MetricsHttpClientWrapper`
- new  mapping for `HttpStatusCode.NotModified => ActionStatus.NotModified` (Success: false)
- fix missing ActionStatus mapping for non success status code in `public async Task<OperationResult<HttpResponseMessage<TResult>>> SendAsync<TModel, TResult>(...)`