### PR TITLE
Group prometheus metrics

### DIFF
--- a/ATI.Services.Common/ATI.Services.Common.csproj
+++ b/ATI.Services.Common/ATI.Services.Common.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="HtmlSanitizer" Version="8.0.692" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.6" />

--- a/ATI.Services.Common/ATI.Services.Common.csproj
+++ b/ATI.Services.Common/ATI.Services.Common.csproj
@@ -4,7 +4,6 @@
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
     <Authors>Team Services</Authors>
     <Company>ATI</Company>
-    <LangVersion>10</LangVersion>
     <PublishReadyToRun>true</PublishReadyToRun>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>atisu.services.common</PackageId>

--- a/ATI.Services.Common/ATI.Services.Common.csproj
+++ b/ATI.Services.Common/ATI.Services.Common.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="HtmlSanitizer" Version="8.0.692" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.6" />

--- a/ATI.Services.Common/ATI.Services.Common.csproj
+++ b/ATI.Services.Common/ATI.Services.Common.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.3" />
     <PackageReference Include="Npgsql" Version="7.0.4" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="prometheus-net" Version="8.0.0" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.50" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />

--- a/ATI.Services.Common/Initializers/MetricsInitializer.cs
+++ b/ATI.Services.Common/Initializers/MetricsInitializer.cs
@@ -25,7 +25,7 @@ namespace ATI.Services.Common.Initializers
                 return Task.CompletedTask;
             }
             
-            MetricsFactory.Init(_metricsOptions.MetricsServiceName, _metricsOptions.DefaultLongRequestTime);
+            MetricsFactory.Init(_metricsOptions.DefaultLongRequestTime);
             
             _initialized = true;
             return Task.CompletedTask;

--- a/ATI.Services.Common/Initializers/MetricsInitializer.cs
+++ b/ATI.Services.Common/Initializers/MetricsInitializer.cs
@@ -25,10 +25,7 @@ namespace ATI.Services.Common.Initializers
                 return Task.CompletedTask;
             }
             
-            if (_metricsOptions.MetricsServiceName != null )
-            {
-                MetricsFactory.Init(_metricsOptions.MetricsServiceName, _metricsOptions.DefaultLongRequestTime);
-            }
+            MetricsFactory.Init(_metricsOptions.MetricsServiceName, _metricsOptions.DefaultLongRequestTime);
             
             _initialized = true;
             return Task.CompletedTask;

--- a/ATI.Services.Common/Logging/LogSource.cs
+++ b/ATI.Services.Common/Logging/LogSource.cs
@@ -13,6 +13,7 @@ namespace ATI.Services.Common.Logging
         Sql = 4,
         Controller = 5, 
         Repository = 6,
-        ExternalHttpClient = 8
+        RabbitMq = 9,
+        Custom = 10
     }
 }

--- a/ATI.Services.Common/Metrics/ExceptionsMetricsCollector.cs
+++ b/ATI.Services.Common/Metrics/ExceptionsMetricsCollector.cs
@@ -1,60 +1,49 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
-using Microsoft.Extensions.Configuration;
 using Prometheus;
-using ConfigurationManager = ATI.Services.Common.Behaviors.ConfigurationManager;
 
-namespace ATI.Services.Common.Metrics
+namespace ATI.Services.Common.Metrics;
+
+public class ExceptionsMetricsCollector : EventListener
 {
-    public class ExceptionsMetricsCollector : EventListener
+    // Да, даже под linux - Microsoft-Windows
+    private const string ExceptionSourceName = "Microsoft-Windows-DotNETRuntime";
+    private const int ExceptionBit = 0x8000;
+    private const int ExceptionNameIndex = 0;
+    private readonly ConcurrentDictionary<string, long> _exceptionCounters = new();
+    private MetricFactory _metricFactory;
+    private Gauge _gauge;
+
+    protected override void OnEventSourceCreated(EventSource eventSource)
     {
-        // Да, даже под linux - Microsoft-Windows
-        private const string ExceptionSourceName = "Microsoft-Windows-DotNETRuntime";
-        private const int ExceptionBit = 0x8000;
-        private const int ExceptionNameIndex = 0;
-        private readonly ConcurrentDictionary<string, long> _exceptionCounters = new();
-        private MetricFactory _metricFactory;
-        private const string ExceptionsMetricName = "Exceptions";
-        private Gauge _gauge;
-
-        private string ServiceName { get; } = "common_default";
-        public ExceptionsMetricsCollector()
-        {
-            if(ConfigurationManager.GetSection(nameof(MetricsOptions))?.Get<MetricsOptions>()?.MetricsServiceName is { } serviceName)
-                ServiceName =  $"common_{serviceName}";
-        }
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name != ExceptionSourceName)
-                return;
+        if (eventSource.Name != ExceptionSourceName)
+            return;
             
-            EnableEvents(
-                eventSource,
-                EventLevel.Error,
-                (EventKeywords) ExceptionBit);
-        }
+        EnableEvents(
+            eventSource,
+            EventLevel.Error,
+            (EventKeywords) ExceptionBit);
+    }
 
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
-        {
-            var exceptionType = eventData.Payload[ExceptionNameIndex].ToString();
-            _exceptionCounters.AddOrUpdate(exceptionType, _ => 1, (_, oldValue) => oldValue + 1);
-        }
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        var exceptionType = eventData.Payload[ExceptionNameIndex].ToString();
+        _exceptionCounters.AddOrUpdate(exceptionType, _ => 1, (_, oldValue) => oldValue + 1);
+    }
 
-        public void RegisterMetrics(CollectorRegistry registry)
-        {
-            _metricFactory = Prometheus.Metrics.WithCustomRegistry(registry);
-            _gauge = _metricFactory.CreateGauge($"{ServiceName}_{ExceptionsMetricName}", "", "machine_name", "exception_type");
-        }
+    public void RegisterMetrics(CollectorRegistry registry)
+    {
+        _metricFactory = Prometheus.Metrics.WithCustomRegistry(registry);
+        _gauge = _metricFactory.CreateGauge($"{MetricsFactory.Prefix}_Exceptions", "", "machine_name", "exception_type");
+    }
 
-        public void UpdateMetrics()
+    public void UpdateMetrics()
+    {
+        foreach (var exceptionType in _exceptionCounters.Keys)
         {
-            foreach (var exceptionType in _exceptionCounters.Keys)
-            {
-                _exceptionCounters.TryRemove(exceptionType, out var count);
-                _gauge.WithLabels(Environment.MachineName, exceptionType).Set(count);
-            }
+            _exceptionCounters.TryRemove(exceptionType, out var count);
+            _gauge.WithLabels(Environment.MachineName, exceptionType).Set(count);
         }
     }
 }

--- a/ATI.Services.Common/Metrics/ExceptionsMetricsCollector.cs
+++ b/ATI.Services.Common/Metrics/ExceptionsMetricsCollector.cs
@@ -21,7 +21,7 @@ namespace ATI.Services.Common.Metrics
         private string ServiceName { get; } = "common_default";
         public ExceptionsMetricsCollector()
         {
-            if(ConfigurationManager.GetSection(nameof(MetricsOptions)).Get<MetricsOptions>().MetricsServiceName is { } serviceName)
+            if(ConfigurationManager.GetSection(nameof(MetricsOptions))?.Get<MetricsOptions>()?.MetricsServiceName is { } serviceName)
                 ServiceName =  $"common_{serviceName}";
         }
 

--- a/ATI.Services.Common/Metrics/ExceptionsMetricsCollector.cs
+++ b/ATI.Services.Common/Metrics/ExceptionsMetricsCollector.cs
@@ -18,10 +18,11 @@ namespace ATI.Services.Common.Metrics
         private const string ExceptionsMetricName = "Exceptions";
         private Gauge _gauge;
 
-        private string ServiceName { get; }
+        private string ServiceName { get; } = "common_default";
         public ExceptionsMetricsCollector()
         {
-            ServiceName = ConfigurationManager.GetSection(nameof(MetricsOptions)).Get<MetricsOptions>().MetricsServiceName;
+            if(ConfigurationManager.GetSection(nameof(MetricsOptions)).Get<MetricsOptions>().MetricsServiceName is { } serviceName)
+                ServiceName =  $"common_{serviceName}";
         }
 
         protected override void OnEventSourceCreated(EventSource eventSource)
@@ -44,7 +45,7 @@ namespace ATI.Services.Common.Metrics
         public void RegisterMetrics(CollectorRegistry registry)
         {
             _metricFactory = Prometheus.Metrics.WithCustomRegistry(registry);
-            _gauge = _metricFactory.CreateGauge(ServiceName + ExceptionsMetricName, "", "machine_name", "exception_type");
+            _gauge = _metricFactory.CreateGauge($"{ServiceName}_{ExceptionsMetricName}", "", "machine_name", "exception_type");
         }
 
         public void UpdateMetrics()

--- a/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
+++ b/ATI.Services.Common/Metrics/HttpWrapper/MetricsHttpClientWrapper.cs
@@ -15,537 +15,525 @@ using ATI.Services.Common.Variables;
 using JetBrains.Annotations;
 using NLog;
 
-namespace ATI.Services.Common.Metrics.HttpWrapper
+namespace ATI.Services.Common.Metrics.HttpWrapper;
+
+/// <summary>
+/// Для удобства лучше использовать ConsulMetricsHttpClientWrapper из ATI.Services.Consul
+/// Он внутри себя инкапсулирует ConsulServiceAddress и MetricsFactory
+/// </summary>
+[PublicAPI]
+public class MetricsHttpClientWrapper
 {
-    /// <summary>
-    /// Для удобства лучше использовать ConsulMetricsHttpClientWrapper из ATI.Services.Consul
-    /// Он внутри себя инкапсулирует ConsulServiceAddress и MetricsFactory
-    /// </summary>
-    [PublicAPI]
-    public class MetricsHttpClientWrapper
+    private readonly ILogger _logger;
+    private readonly HttpClient _httpClient;
+    private readonly Func<LogLevel, LogLevel> _logLevelOverride;
+
+    private const string LogMessageTemplate =
+        "Сервис:{0} в ответ на запрос [HTTP {1} {2}] вернул ответ с статус кодом {3}.";
+
+    public MetricsHttpClientWrapper(MetricsHttpClientConfig config)
     {
-        private readonly ILogger _logger;
-        private readonly HttpClient _httpClient;
-        private readonly MetricsFactory _metricsFactory;
-        private readonly Func<LogLevel, LogLevel> _logLevelOverride;
+        Config = config;
+        _logger = LogManager.GetLogger(Config.ServiceName);
+        _httpClient = CreateHttpClient(config.Headers, config.PropagateActivity);
+        _logLevelOverride = Config.LogLevelOverride;
+    }
 
-        private const string LogMessageTemplate =
-            "Сервис:{0} в ответ на запрос [HTTP {1} {2}] вернул ответ с статус кодом {3}.";
+    public MetricsHttpClientConfig Config { get; }
 
-        public MetricsHttpClientWrapper(MetricsHttpClientConfig config)
+    private HttpClient CreateHttpClient(Dictionary<string, string> additionalHeaders, bool propagateActivity = true)
+    {
+        HttpClient httpClient;
+        if (propagateActivity)
         {
-            Config = config;
-            _logger = LogManager.GetLogger(Config.ServiceName);
-            _httpClient = CreateHttpClient(config.Headers, config.PropagateActivity);
-            _metricsFactory = MetricsFactory.CreateExternalHttpMetricsFactory();
-            _logLevelOverride = Config.LogLevelOverride;
+            httpClient = new HttpClient();
+        }
+        else
+        {
+            httpClient = new HttpClient(new SocketsHttpHandler
+            {
+                ActivityHeadersPropagator = DistributedContextPropagator.CreateNoOutputPropagator()
+            });
         }
 
-        public MetricsHttpClientConfig Config { get; }
-
-        private HttpClient CreateHttpClient(Dictionary<string, string> additionalHeaders, bool propagateActivity = true)
+        httpClient.Timeout = Config.Timeout;
+        httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        if (!ServiceVariables.ServiceAsClientName.IsNullOrEmpty() &&
+            !ServiceVariables.ServiceAsClientHeaderName.IsNullOrEmpty())
         {
-            HttpClient httpClient;
-            if (propagateActivity)
-            {
-                httpClient = new HttpClient();
-            }
-            else
-            {
-                httpClient = new HttpClient(new SocketsHttpHandler
-                {
-                    ActivityHeadersPropagator = DistributedContextPropagator.CreateNoOutputPropagator()
-                });
-            }
-
-            httpClient.Timeout = Config.Timeout;
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            if (!ServiceVariables.ServiceAsClientName.IsNullOrEmpty() &&
-                !ServiceVariables.ServiceAsClientHeaderName.IsNullOrEmpty())
-            {
-                httpClient.DefaultRequestHeaders.Add(
-                    ServiceVariables.ServiceAsClientHeaderName,
-                    ServiceVariables.ServiceAsClientName);
-            }
-
-            if (additionalHeaders != null && additionalHeaders.Count > 0)
-            {
-                foreach (var header in additionalHeaders)
-                {
-                    httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
-                }
-            }
-
-            return httpClient;
+            httpClient.DefaultRequestHeaders.Add(
+                ServiceVariables.ServiceAsClientHeaderName,
+                ServiceVariables.ServiceAsClientName);
         }
 
-
-        public async Task<OperationResult<TModel>> GetAsync<TModel>(Uri fullUrl, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync<TModel>(metricName, new HttpMessage(HttpMethod.Get, fullUrl, headers));
-
-
-        public async Task<OperationResult<TModel>> GetAsync<TModel>(string serviceAddress, string metricName,
-            string url, Dictionary<string, string> headers = null)
-            => await SendAsync<TModel>(metricName,
-                new HttpMessage(HttpMethod.Get, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<string>> GetAsync(string serviceAddress, string metricName, string url,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Get, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<string>> GetAsync(Uri fullUrl, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Get, fullUrl, headers));
-
-
-        public async Task<OperationResult<TResult>> PostAsync<TModel, TResult>(string serviceAddress, string metricName,
-            string url, TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers)
-                {
-                    Content = Config.Serializer.Serialize(model)
-                });
-
-
-        public async Task<OperationResult<TResult>> PostAsync<TModel, TResult>(Uri fullUrl, string metricName,
-            TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers)
-            {
-                Content = Config.Serializer.Serialize(model)
-            });
-
-
-        public async Task<OperationResult<string>> PostAsync<TModel>(string serviceAddress, string metricName,
-            string url, TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers)
-            {
-                Content = Config.Serializer.Serialize(model)
-            });
-
-
-        public async Task<OperationResult<string>> PostAsync<TModel>(Uri fullUrl, string metricName, TModel model,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers)
-            {
-                Content = Config.Serializer.Serialize(model)
-            });
-
-
-        public async Task<OperationResult<TResult>> PostAsync<TResult>(string serviceAddress, string metricName,
-            string url, string rawContent, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers)
-                {
-                    Content = rawContent
-                });
-
-
-        public async Task<OperationResult<TResult>> PostAsync<TResult>(Uri fullUrl, string metricName,
-            string rawContent, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers)
-            {
-                Content = rawContent
-            });
-
-
-        public async Task<OperationResult<TResult>> PostAsync<TResult>(string serviceAddress, string metricName,
-            string url, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<TResult>> PostAsync<TResult>(Uri fullUrl, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers));
-
-
-        public async Task<OperationResult<string>> PostAsync(string serviceAddress, string metricName, string url,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<string>> PostAsync(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, fullUri, headers));
-
-
-        public async Task<OperationResult<string>> PostAsync(string serviceAddress, string metricName, string url,
-            string rawContent, Dictionary<string, string> headers = null)
-            => await SendAsync(metricName,
-                new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers) { Content = rawContent });
-
-
-        public async Task<OperationResult<string>> PostAsync(Uri fullUri, string metricName, string rawContent,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, fullUri, headers) { Content = rawContent });
-
-
-        public async Task<OperationResult<TResult>> PutAsync<TModel, TResult>(string serviceAddress, string metricName,
-            string url, TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Put, FullUri(serviceAddress, url), headers)
-                {
-                    Content = Config.Serializer.Serialize(model)
-                });
-
-
-        public async Task<OperationResult<TResult>> PutAsync<TModel, TResult>(Uri fullUri, string metricName,
-            TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Put, fullUri, headers)
-            {
-                Content = Config.Serializer.Serialize(model)
-            });
-
-
-        public async Task<OperationResult<TResult>> PutAsync<TResult>(string serviceAddress, string metricName,
-            string url, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Put, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<TResult>> PutAsync<TResult>(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Put, fullUri, headers));
-
-
-        public async Task<OperationResult<string>> PutAsync(string serviceAddress, string metricName, string url,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Put, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<string>> PutAsync(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Put, fullUri, headers));
-
-
-        public async Task<OperationResult<TResult>> DeleteAsync<TModel, TResult>(string serviceAddress,
-            string metricName, string url, TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Delete, FullUri(serviceAddress, url), headers)
-                {
-                    Content = Config.Serializer.Serialize(model)
-                });
-
-
-        public async Task<OperationResult<TResult>> DeleteAsync<TResult>(string serviceAddress, string metricName,
-            string url, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Delete, FullUri(serviceAddress, url), headers));
-
-        public async Task<OperationResult<TResult>> DeleteAsync<TResult>(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Delete, fullUri, headers));
-
-
-        public async Task<OperationResult<string>> DeleteAsync(string serviceAddress, string metricName, string url,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Delete, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<string>> DeleteAsync(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Delete, fullUri, headers));
-
-
-        public async Task<OperationResult<TResult>> PatchAsync<TModel, TResult>(string serviceAddress,
-            string metricName,
-            string url, TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers)
-                {
-                    Content = Config.Serializer.Serialize(model)
-                });
-
-
-        public async Task<OperationResult<TResult>> PatchAsync<TModel, TResult>(Uri fullUri, string metricName,
-            TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers)
-            {
-                Content = Config.Serializer.Serialize(model)
-            });
-
-
-        public async Task<OperationResult<TResult>> PatchAsync<TResult>(string serviceAddress, string metricName,
-            string url, Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName,
-                new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<TResult>> PatchAsync<TResult>(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers));
-
-
-        public async Task<OperationResult<string>> PatchAsync<TModel>(string serviceAddress, string metricName,
-            string url, TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<string>(metricName,
-                new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers)
-                {
-                    Content = Config.Serializer.Serialize(model)
-                });
-
-
-        public async Task<OperationResult<string>> PatchAsync<TModel>(Uri fullUri, string metricName,
-            TModel model, Dictionary<string, string> headers = null)
-            => await SendAsync<string>(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers)
-            {
-                Content = Config.Serializer.Serialize(model)
-            });
-
-
-        public async Task<OperationResult<string>> PatchAsync(string serviceAddress, string metricName, string url,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers));
-
-
-        public async Task<OperationResult<string>> PatchAsync(Uri fullUri, string metricName,
-            Dictionary<string, string> headers = null)
-            => await SendAsync(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers));
-
-
-        public async Task<OperationResult<HttpResponseMessage<TResult>>> SendAsync<TModel, TResult>(Uri fullUri,
-            string metricName, TModel model,
-            Dictionary<string, string> headers = null,
-            HttpMethod method = null)
+        if (additionalHeaders != null && additionalHeaders.Count > 0)
         {
+            foreach (var header in additionalHeaders)
+            {
+                httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
+        }
+
+        return httpClient;
+    }
+
+
+    public async Task<OperationResult<TModel>> GetAsync<TModel>(Uri fullUrl, string metricName,
+                                                                Dictionary<string, string> headers = null)
+        => await SendAsync<TModel>(metricName, new HttpMessage(HttpMethod.Get, fullUrl, headers));
+
+
+    public async Task<OperationResult<TModel>> GetAsync<TModel>(string serviceAddress, string metricName,
+                                                                string url, Dictionary<string, string> headers = null)
+        => await SendAsync<TModel>(metricName,
+                                   new HttpMessage(HttpMethod.Get, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<string>> GetAsync(string serviceAddress, string metricName, string url,
+                                                        Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Get, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<string>> GetAsync(Uri fullUrl, string metricName,
+                                                        Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Get, fullUrl, headers));
+
+
+    public async Task<OperationResult<TResult>> PostAsync<TModel, TResult>(string serviceAddress, string metricName,
+                                                                           string url, TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers)
+                                    {
+                                        Content = Config.Serializer.Serialize(model)
+                                    });
+
+
+    public async Task<OperationResult<TResult>> PostAsync<TModel, TResult>(Uri fullUrl, string metricName,
+                                                                           TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers)
+        {
+            Content = Config.Serializer.Serialize(model)
+        });
+
+
+    public async Task<OperationResult<string>> PostAsync<TModel>(string serviceAddress, string metricName,
+                                                                 string url, TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers)
+        {
+            Content = Config.Serializer.Serialize(model)
+        });
+
+
+    public async Task<OperationResult<string>> PostAsync<TModel>(Uri fullUrl, string metricName, TModel model,
+                                                                 Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers)
+        {
+            Content = Config.Serializer.Serialize(model)
+        });
+
+
+    public async Task<OperationResult<TResult>> PostAsync<TResult>(string serviceAddress, string metricName,
+                                                                   string url, string rawContent, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers)
+                                    {
+                                        Content = rawContent
+                                    });
+
+
+    public async Task<OperationResult<TResult>> PostAsync<TResult>(Uri fullUrl, string metricName,
+                                                                   string rawContent, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers)
+        {
+            Content = rawContent
+        });
+
+
+    public async Task<OperationResult<TResult>> PostAsync<TResult>(string serviceAddress, string metricName,
+                                                                   string url, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<TResult>> PostAsync<TResult>(Uri fullUrl, string metricName,
+                                                                   Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Post, fullUrl, headers));
+
+
+    public async Task<OperationResult<string>> PostAsync(string serviceAddress, string metricName, string url,
+                                                         Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<string>> PostAsync(Uri fullUri, string metricName,
+                                                         Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, fullUri, headers));
+
+
+    public async Task<OperationResult<string>> PostAsync(string serviceAddress, string metricName, string url,
+                                                         string rawContent, Dictionary<string, string> headers = null)
+        => await SendAsync(metricName,
+                           new HttpMessage(HttpMethod.Post, FullUri(serviceAddress, url), headers) { Content = rawContent });
+
+
+    public async Task<OperationResult<string>> PostAsync(Uri fullUri, string metricName, string rawContent,
+                                                         Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Post, fullUri, headers) { Content = rawContent });
+
+
+    public async Task<OperationResult<TResult>> PutAsync<TModel, TResult>(string serviceAddress, string metricName,
+                                                                          string url, TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Put, FullUri(serviceAddress, url), headers)
+                                    {
+                                        Content = Config.Serializer.Serialize(model)
+                                    });
+
+
+    public async Task<OperationResult<TResult>> PutAsync<TModel, TResult>(Uri fullUri, string metricName,
+                                                                          TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Put, fullUri, headers)
+        {
+            Content = Config.Serializer.Serialize(model)
+        });
+
+
+    public async Task<OperationResult<TResult>> PutAsync<TResult>(string serviceAddress, string metricName,
+                                                                  string url, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Put, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<TResult>> PutAsync<TResult>(Uri fullUri, string metricName,
+                                                                  Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Put, fullUri, headers));
+
+
+    public async Task<OperationResult<string>> PutAsync(string serviceAddress, string metricName, string url,
+                                                        Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Put, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<string>> PutAsync(Uri fullUri, string metricName,
+                                                        Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Put, fullUri, headers));
+
+
+    public async Task<OperationResult<TResult>> DeleteAsync<TModel, TResult>(string serviceAddress,
+                                                                             string metricName, string url, TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Delete, FullUri(serviceAddress, url), headers)
+                                    {
+                                        Content = Config.Serializer.Serialize(model)
+                                    });
+
+
+    public async Task<OperationResult<TResult>> DeleteAsync<TResult>(string serviceAddress, string metricName,
+                                                                     string url, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Delete, FullUri(serviceAddress, url), headers));
+
+    public async Task<OperationResult<TResult>> DeleteAsync<TResult>(Uri fullUri, string metricName,
+                                                                     Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Delete, fullUri, headers));
+
+
+    public async Task<OperationResult<string>> DeleteAsync(string serviceAddress, string metricName, string url,
+                                                           Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Delete, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<string>> DeleteAsync(Uri fullUri, string metricName,
+                                                           Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Delete, fullUri, headers));
+
+
+    public async Task<OperationResult<TResult>> PatchAsync<TModel, TResult>(string serviceAddress,
+                                                                            string metricName,
+                                                                            string url, TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers)
+                                    {
+                                        Content = Config.Serializer.Serialize(model)
+                                    });
+
+
+    public async Task<OperationResult<TResult>> PatchAsync<TModel, TResult>(Uri fullUri, string metricName,
+                                                                            TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers)
+        {
+            Content = Config.Serializer.Serialize(model)
+        });
+
+
+    public async Task<OperationResult<TResult>> PatchAsync<TResult>(string serviceAddress, string metricName,
+                                                                    string url, Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName,
+                                    new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<TResult>> PatchAsync<TResult>(Uri fullUri, string metricName,
+                                                                    Dictionary<string, string> headers = null)
+        => await SendAsync<TResult>(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers));
+
+
+    public async Task<OperationResult<string>> PatchAsync<TModel>(string serviceAddress, string metricName,
+                                                                  string url, TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<string>(metricName,
+                                   new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers)
+                                   {
+                                       Content = Config.Serializer.Serialize(model)
+                                   });
+
+
+    public async Task<OperationResult<string>> PatchAsync<TModel>(Uri fullUri, string metricName,
+                                                                  TModel model, Dictionary<string, string> headers = null)
+        => await SendAsync<string>(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers)
+        {
+            Content = Config.Serializer.Serialize(model)
+        });
+
+
+    public async Task<OperationResult<string>> PatchAsync(string serviceAddress, string metricName, string url,
+                                                          Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Patch, FullUri(serviceAddress, url), headers));
+
+
+    public async Task<OperationResult<string>> PatchAsync(Uri fullUri, string metricName,
+                                                          Dictionary<string, string> headers = null)
+        => await SendAsync(metricName, new HttpMessage(HttpMethod.Patch, fullUri, headers));
+
+
+    public async Task<OperationResult<HttpResponseMessage<TResult>>> SendAsync<TModel, TResult>(Uri fullUri,
+        string metricName, TModel model,
+        Dictionary<string, string> headers = null,
+        HttpMethod method = null)
+    {
+        try
+        {
+            if (fullUri == null)
+                return new OperationResult<HttpResponseMessage<TResult>>(ActionStatus.InternalServerError,
+                                                                         "Адрес сообщения не указан (fullUri==null)");
+
+            var message = new HttpMessage(method ?? HttpMethod.Put, fullUri, headers)
+            {
+                Content = model != null ? Config.Serializer.Serialize(model) : ""
+            };
+
+            using var requestMessage = message.ToRequestMessage(Config);
+
+            using var responseMessage = await _httpClient.SendAsync(requestMessage);
+            var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!responseMessage.IsSuccessStatusCode)
+            {
+                var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
+                                               message.FullUri, responseMessage.StatusCode);
+
+                var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
+                                   ? _logLevelOverride(LogLevel.Error)
+                                   : _logLevelOverride(LogLevel.Warn);
+                _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
+            }
+
+            var result = new HttpResponseMessage<TResult>
+            {
+                StatusCode = responseMessage.StatusCode,
+                Headers = responseMessage.Headers,
+                TrailingHeaders = responseMessage.TrailingHeaders,
+                ReasonPhrase = responseMessage.ReasonPhrase,
+                Version = responseMessage.Version,
+                RawContent = responseContent
+            };
+
             try
             {
-                if (fullUri == null)
-                    return new OperationResult<HttpResponseMessage<TResult>>(ActionStatus.InternalServerError,
-                        "Адрес сообщения не указан (fullUri==null)");
-
-                var message = new HttpMessage(method ?? HttpMethod.Put, fullUri, headers)
-                {
-                    Content = model != null ? Config.Serializer.Serialize(model) : ""
-                };
-
-                using (_metricsFactory.CreateMetricsTimer(metricName, message.Content))
-                {
-                    using var requestMessage = message.ToRequestMessage(Config);
-
-                    using var responseMessage = await _httpClient.SendAsync(requestMessage);
-                    var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-                    if (!responseMessage.IsSuccessStatusCode)
-                    {
-                        var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
-                            message.FullUri, responseMessage.StatusCode);
-
-                        var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
-                            ? _logLevelOverride(LogLevel.Error)
-                            : _logLevelOverride(LogLevel.Warn);
-                        _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
-                    }
-
-                    var result = new HttpResponseMessage<TResult>
-                    {
-                        StatusCode = responseMessage.StatusCode,
-                        Headers = responseMessage.Headers,
-                        TrailingHeaders = responseMessage.TrailingHeaders,
-                        ReasonPhrase = responseMessage.ReasonPhrase,
-                        Version = responseMessage.Version,
-                        RawContent = responseContent
-                    };
-
-                    try
-                    {
-                        result.Content = !string.IsNullOrEmpty(result.RawContent)
-                                             ? Config.Serializer.Deserialize<TResult>(result.RawContent)
-                                             : default;
-                    }
-                    catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
-                    {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Warn),
-                            e,
-                            logObjects: new
-                            {
-                                MetricName = metricName, FullUri = fullUri, Model = model,
-                                Headers = headers
-                            });
-                        return new OperationResult<HttpResponseMessage<TResult>>(ActionStatus.Timeout);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
-                            e,
-                            logObjects:
-                            new
-                            {
-                                MetricName = metricName, FullUri = fullUri, Model = model,
-                                Headers = headers,
-                                ResponseBody = result.RawContent
-                            });
-                    }
-
-                    return new(result, OperationResult.GetActionStatusByHttpStatusCode(result.StatusCode));
-                }
+                result.Content = !string.IsNullOrEmpty(result.RawContent)
+                                     ? Config.Serializer.Deserialize<TResult>(result.RawContent)
+                                     : default;
+            }
+            catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
+            {
+                _logger.LogWithObject(_logLevelOverride(LogLevel.Warn),
+                                      e,
+                                      logObjects: new
+                                      {
+                                          MetricName = metricName, FullUri = fullUri, Model = model,
+                                          Headers = headers
+                                      });
+                return new OperationResult<HttpResponseMessage<TResult>>(ActionStatus.Timeout);
             }
             catch (Exception e)
             {
                 _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
-                    e,
-                    logObjects: new { MetricName = metricName, FullUri = fullUri, Model = model, Headers = headers });
-                return new OperationResult<HttpResponseMessage<TResult>>(e);
+                                      e,
+                                      logObjects:
+                                      new
+                                      {
+                                          MetricName = metricName, FullUri = fullUri, Model = model,
+                                          Headers = headers,
+                                          ResponseBody = result.RawContent
+                                      });
+            }
+
+            return new(result, OperationResult.GetActionStatusByHttpStatusCode(result.StatusCode));
+        }
+        catch (Exception e)
+        {
+            _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
+                                  e,
+                                  logObjects: new { MetricName = metricName, FullUri = fullUri, Model = model, Headers = headers });
+            return new OperationResult<HttpResponseMessage<TResult>>(e);
+        }
+    }
+
+    private async Task<OperationResult<TResult>> SendAsync<TResult>(string methodName, HttpMessage message)
+    {
+        try
+        {
+            if (message.FullUri == null)
+                return new OperationResult<TResult>(ActionStatus.InternalServerError,
+                                                    "Адрес сообщения не указан (message.FullUri==null)");
+
+            using var requestMessage = message.ToRequestMessage(Config);
+
+            using var responseMessage = await _httpClient.SendAsync(requestMessage);
+
+            if (responseMessage.IsSuccessStatusCode)
+            {
+                var stream = await responseMessage.Content.ReadAsStreamAsync();
+                var result = await Config.Serializer.DeserializeAsync<TResult>(stream);
+                return new OperationResult<TResult>(result, OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
+            }
+
+            var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
+                                           message.FullUri, responseMessage.StatusCode);
+            var responseContent = await responseMessage.Content.ReadAsStringAsync();
+
+            var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
+                               ? _logLevelOverride(LogLevel.Error)
+                               : _logLevelOverride(LogLevel.Warn);
+            _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
+
+            return new OperationResult<TResult>(OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
+        }
+        catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
+        {
+            _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
+                                  e,
+                                  logObjects: new { Method = methodName, Message = message });
+            return new OperationResult<TResult>(ActionStatus.Timeout);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
+                                  e,
+                                  logObjects: new { Method = methodName, Message = message });
+            return new OperationResult<TResult>(e);
+        }
+    }
+
+    private async Task<OperationResult<string>> SendAsync(string methodName, HttpMessage message)
+    {
+        try
+        {
+            if (message.FullUri == null)
+                return new OperationResult<string>(ActionStatus.InternalServerError);
+
+            using var requestMessage = message.ToRequestMessage(Config);
+
+            using var responseMessage = await _httpClient.SendAsync(requestMessage);
+            var responseContent = await responseMessage.Content.ReadAsStringAsync();
+
+            if (responseMessage.IsSuccessStatusCode)
+                return new OperationResult<string>(responseContent, OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
+
+            var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
+                                           message.FullUri, responseMessage.StatusCode);
+
+            var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
+                               ? _logLevelOverride(LogLevel.Error)
+                               : _logLevelOverride(LogLevel.Warn);
+            _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
+
+            return new OperationResult<string>(responseContent,
+                                               OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
+        }
+        catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
+        {
+            _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
+                                  e,
+                                  logObjects: new { Method = methodName, Message = message });
+            return new OperationResult<string>(ActionStatus.Timeout);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
+                                  e,
+                                  logObjects: new { Method = methodName, Message = message });
+            return new OperationResult<string>(e);
+        }
+    }
+
+    private Uri FullUri(string serviceAddress, string url) =>
+        serviceAddress != null ? new Uri(new Uri(serviceAddress), url ?? "") : null;
+
+    private class HttpMessage
+    {
+        private readonly string ContentTypeHeaderName = "Content-Type";
+
+        public HttpMessage(HttpMethod method, Uri fullUri, Dictionary<string, string> headers)
+        {
+            Method = method;
+            FullUri = fullUri;
+            Headers = new Dictionary<string, string>();
+            ContentType = "application/json";
+
+            if (headers == null)
+                return;
+
+            foreach (var header in headers)
+            {
+                if (string.Equals(header.Key, ContentTypeHeaderName,
+                                  StringComparison.InvariantCultureIgnoreCase))
+                {
+                    ContentType = header.Value;
+                }
+                else
+                {
+                    Headers.Add(header.Key, header.Value);
+                }
             }
         }
 
-        private async Task<OperationResult<TResult>> SendAsync<TResult>(string methodName, HttpMessage message)
+        public HttpMethod Method { get; }
+        public string Content { get; init; }
+        public Uri FullUri { get; }
+        public Dictionary<string, string> Headers { get; }
+        private string ContentType { get; }
+
+        internal HttpRequestMessage ToRequestMessage(MetricsHttpClientConfig config)
         {
-            using (_metricsFactory.CreateMetricsTimer(methodName, message.Content))
+            var msg = new HttpRequestMessage(Method, FullUri);
+
+            if (config.HeadersToProxy.Count != 0)
+                Headers.AddRange(AppHttpContext.HeadersAndValuesToProxy(config.HeadersToProxy));
+
+            foreach (var header in Headers)
+                msg.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+            string acceptLanguage;
+            if (config.AddCultureToRequest
+                && (acceptLanguage = FlowContext<RequestMetaData>.Current.AcceptLanguage) != null)
+                msg.Headers.Add("Accept-Language", acceptLanguage);
+
+
+            if (string.IsNullOrEmpty(Content) == false)
             {
-                try
-                {
-                    if (message.FullUri == null)
-                        return new OperationResult<TResult>(ActionStatus.InternalServerError,
-                            "Адрес сообщения не указан (message.FullUri==null)");
-
-                    using var requestMessage = message.ToRequestMessage(Config);
-
-                    using var responseMessage = await _httpClient.SendAsync(requestMessage);
-
-                    if (responseMessage.IsSuccessStatusCode)
-                    {
-                        var stream = await responseMessage.Content.ReadAsStreamAsync();
-                        var result = await Config.Serializer.DeserializeAsync<TResult>(stream);
-                        return new OperationResult<TResult>(result, OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
-                    }
-
-                    var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
-                        message.FullUri, responseMessage.StatusCode);
-                    var responseContent = await responseMessage.Content.ReadAsStringAsync();
-
-                    var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
-                        ? _logLevelOverride(LogLevel.Error)
-                        : _logLevelOverride(LogLevel.Warn);
-                    _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
-
-                    return new OperationResult<TResult>(OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
-                }
-                catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
-                {
-                    _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
-                        e,
-                        logObjects: new { Method = methodName, Message = message });
-                    return new OperationResult<TResult>(ActionStatus.Timeout);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
-                        e,
-                        logObjects: new { Method = methodName, Message = message });
-                    return new OperationResult<TResult>(e);
-                }
-            }
-        }
-
-        private async Task<OperationResult<string>> SendAsync(string methodName, HttpMessage message)
-        {
-            using (_metricsFactory.CreateMetricsTimer(methodName, message.Content))
-            {
-                try
-                {
-                    if (message.FullUri == null)
-                        return new OperationResult<string>(ActionStatus.InternalServerError);
-
-                    using var requestMessage = message.ToRequestMessage(Config);
-
-                    using var responseMessage = await _httpClient.SendAsync(requestMessage);
-                    var responseContent = await responseMessage.Content.ReadAsStringAsync();
-
-                    if (responseMessage.IsSuccessStatusCode)
-                        return new OperationResult<string>(responseContent, OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
-
-                    var logMessage = string.Format(LogMessageTemplate, Config.ServiceName, message.Method,
-                        message.FullUri, responseMessage.StatusCode);
-
-                    var logLevel = responseMessage.StatusCode == HttpStatusCode.InternalServerError
-                        ? _logLevelOverride(LogLevel.Error)
-                        : _logLevelOverride(LogLevel.Warn);
-                    _logger.LogWithObject(logLevel, ex: null, logMessage, logObjects: responseContent);
-
-                    return new OperationResult<string>(responseContent,
-                        OperationResult.GetActionStatusByHttpStatusCode(responseMessage.StatusCode));
-                }
-                catch (TaskCanceledException e) when (e.InnerException is TimeoutException)
-                {
-                    _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
-                        e,
-                        logObjects: new { Method = methodName, Message = message });
-                    return new OperationResult<string>(ActionStatus.Timeout);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogWithObject(_logLevelOverride(LogLevel.Error),
-                        e,
-                        logObjects: new { Method = methodName, Message = message });
-                    return new OperationResult<string>(e);
-                }
-            }
-        }
-
-        private Uri FullUri(string serviceAddress, string url) =>
-            serviceAddress != null ? new Uri(new Uri(serviceAddress), url ?? "") : null;
-
-        private class HttpMessage
-        {
-            private readonly string ContentTypeHeaderName = "Content-Type";
-
-            public HttpMessage(HttpMethod method, Uri fullUri, Dictionary<string, string> headers)
-            {
-                Method = method;
-                FullUri = fullUri;
-                Headers = new Dictionary<string, string>();
-                ContentType = "application/json";
-
-                if (headers == null)
-                    return;
-
-                foreach (var header in headers)
-                {
-                    if (string.Equals(header.Key, ContentTypeHeaderName,
-                            StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        ContentType = header.Value;
-                    }
-                    else
-                    {
-                        Headers.Add(header.Key, header.Value);
-                    }
-                }
+                msg.Content = new StringContent(Content, Encoding.UTF8, ContentType);
             }
 
-            public HttpMethod Method { get; }
-            public string Content { get; init; }
-            public Uri FullUri { get; }
-            public Dictionary<string, string> Headers { get; }
-            private string ContentType { get; }
-
-            internal HttpRequestMessage ToRequestMessage(MetricsHttpClientConfig config)
-            {
-                var msg = new HttpRequestMessage(Method, FullUri);
-
-                if (config.HeadersToProxy.Count != 0)
-                    Headers.AddRange(AppHttpContext.HeadersAndValuesToProxy(config.HeadersToProxy));
-
-                foreach (var header in Headers)
-                    msg.Headers.TryAddWithoutValidation(header.Key, header.Value);
-
-                string acceptLanguage;
-                if (config.AddCultureToRequest
-                    && (acceptLanguage = FlowContext<RequestMetaData>.Current.AcceptLanguage) != null)
-                    msg.Headers.Add("Accept-Language", acceptLanguage);
-
-
-                if (string.IsNullOrEmpty(Content) == false)
-                {
-                    msg.Content = new StringContent(Content, Encoding.UTF8, ContentType);
-                }
-
-                return msg;
-            }
+            return msg;
         }
     }
 }

--- a/ATI.Services.Common/Metrics/MeasureAttribute.cs
+++ b/ATI.Services.Common/Metrics/MeasureAttribute.cs
@@ -1,91 +1,69 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
-using ATI.Services.Common.Behaviors;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 
-namespace ATI.Services.Common.Metrics
+namespace ATI.Services.Common.Metrics;
+
+[PublicAPI]
+public class MeasureAttribute : ActionFilterAttribute
 {
-    [PublicAPI]
-    public class MeasureAttribute : ActionFilterAttribute
+    private string _metricEntity;
+    private readonly TimeSpan? _longRequestTime;
+    private readonly bool _longRequestLoggingEnabled = true;
+        
+    private static readonly ConcurrentDictionary<string, MetricsFactory> ControllerNameMetricsFactories
+        = new();
+
+    public MeasureAttribute() { }
+
+    public MeasureAttribute(string metricEntity) => _metricEntity = metricEntity;
+
+    /// <param name="metricEntity">Имя метрики</param>
+    /// <param name="longRequestTimeSeconds">Время ответа после которого запрос считается достаточно долгим для логирования. В секундах</param>
+    public MeasureAttribute(string metricEntity, double longRequestTimeSeconds) : this(metricEntity) =>
+        _longRequestTime = TimeSpan.FromSeconds(longRequestTimeSeconds);
+
+    public MeasureAttribute(string metricEntity, bool longRequestLoggingEnabled) : this(metricEntity) =>
+        _longRequestLoggingEnabled = longRequestLoggingEnabled;
+
+    public MeasureAttribute(double longRequestTimeSeconds) =>
+        _longRequestTime = TimeSpan.FromSeconds(longRequestTimeSeconds);
+
+    public MeasureAttribute(bool longRequestLoggingEnabled)
     {
-        private string _metricEntity;
-        private readonly TimeSpan? _longRequestTime;
-        private readonly bool _longRequestLoggingEnabled = true;
-        
-        private static readonly ConcurrentDictionary<string, MetricsFactory> ControllerNameMetricsFactories
-            = new();
+        _longRequestLoggingEnabled = longRequestLoggingEnabled;
+    }
 
-        public MeasureAttribute()
+    public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var controllerActionDescriptor = (ControllerActionDescriptor)context.ActionDescriptor;
+        var actionName =
+            $"{context.HttpContext.Request.Method}:{controllerActionDescriptor.AttributeRouteInfo.Template}";
+        var controllerName = controllerActionDescriptor.ControllerName + "Controller";
+
+        if (string.IsNullOrEmpty(_metricEntity))
         {
+            _metricEntity = controllerActionDescriptor.ControllerName;
         }
 
-        public MeasureAttribute(string metricEntity)
+        var metricsFactory =
+            ControllerNameMetricsFactories.GetOrAdd(
+                controllerName,
+                MetricsFactory.CreateControllerMetricsFactory(controllerName));
+
+        using (CreateTimer(context, metricsFactory, actionName))
         {
-            _metricEntity = metricEntity;
+            await next.Invoke();
         }
-        
-        /// <param name="metricEntity">Имя метрики</param>
-        /// <param name="longRequestTimeSeconds">Время ответа после которого запрос считается достаточно долгим для логирования. В секундах</param>
-        public MeasureAttribute(string metricEntity, double longRequestTimeSeconds) : this(metricEntity)
-        {
-            _longRequestTime = TimeSpan.FromSeconds(longRequestTimeSeconds);
-        }
+    }
 
-        public MeasureAttribute(string metricEntity, bool longRequestLoggingEnabled) : this(metricEntity)
-        {
-            _longRequestLoggingEnabled = longRequestLoggingEnabled;
-        }
-
-        public MeasureAttribute(double longRequestTimeSeconds)
-        {
-            _longRequestTime = TimeSpan.FromSeconds(longRequestTimeSeconds);
-        }
-
-        public MeasureAttribute(bool longRequestLoggingEnabled)
-        {
-            _longRequestLoggingEnabled = longRequestLoggingEnabled;
-        }
-
-        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
-        {
-            var controllerActionDescriptor = (ControllerActionDescriptor)context.ActionDescriptor;
-            var actionName =
-                $"{context.HttpContext.Request.Method}:{controllerActionDescriptor.AttributeRouteInfo.Template}";
-            var controllerName = controllerActionDescriptor.ControllerName + "Controller";
-
-            if (string.IsNullOrEmpty(_metricEntity))
-            {
-                _metricEntity = controllerActionDescriptor.ControllerName;
-            }
-
-            var metricsFactory =
-                ControllerNameMetricsFactories.GetOrAdd(
-                    controllerName,
-                    MetricsFactory.CreateControllerMetricsFactory(controllerName, "client_header_name"));
-
-            var serviceName = "Unknown";
-            
-            if (context.HttpContext.Items.TryGetValue(CommonBehavior.ServiceNameItemKey, out var serviceNameValue))
-            {
-                serviceName = serviceNameValue as string;
-            }
-
-            using (CreateTimer(context, metricsFactory, actionName, serviceName))
-            {
-                await next.Invoke();
-            }
-        }
-
-        private IDisposable CreateTimer(ActionExecutingContext context, MetricsFactory metricsFactory,
-            string actionName, string serviceName)
-        {
-            return _longRequestLoggingEnabled
-                ? metricsFactory.CreateLoggingMetricsTimer(_metricEntity, actionName, context.ActionArguments,
-                    _longRequestTime, serviceName)
-                : metricsFactory.CreateMetricsTimer(_metricEntity, actionName, serviceName);
-        }
+    private IDisposable CreateTimer(ActionExecutingContext context, MetricsFactory metricsFactory, string actionName)
+    {
+        return _longRequestLoggingEnabled
+                   ? metricsFactory.CreateLoggingMetricsTimer(_metricEntity, actionName, context.ActionArguments, _longRequestTime)
+                   : metricsFactory.CreateMetricsTimer(_metricEntity, actionName);
     }
 }

--- a/ATI.Services.Common/Metrics/MetricsExtensions.cs
+++ b/ATI.Services.Common/Metrics/MetricsExtensions.cs
@@ -16,7 +16,7 @@ public static class MetricsExtensions
     /// <summary>
     /// Alias to distinguish from Microsoft.Extensions.DependencyInjection.MetricsServiceExtensions.AddMetrics(IServiceCollection) 
     /// </summary>
-    public static void AddAtiMetrics(this IServiceCollection services) => services.AddMetrics();
+    public static void AddCommonMetrics(this IServiceCollection services) => services.AddMetrics();
 
     public static void AddMetrics(this IServiceCollection services)
     {

--- a/ATI.Services.Common/Metrics/MetricsExtensions.cs
+++ b/ATI.Services.Common/Metrics/MetricsExtensions.cs
@@ -8,35 +8,39 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ConfigurationManager = ATI.Services.Common.Behaviors.ConfigurationManager;
 
-namespace ATI.Services.Common.Metrics
+namespace ATI.Services.Common.Metrics;
+
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+public static class MetricsExtensions
 {
-    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-    public static class MetricsExtensions
+    /// <summary>
+    /// Alias to distinguish from Microsoft.Extensions.DependencyInjection.MetricsServiceExtensions.AddMetrics(IServiceCollection) 
+    /// </summary>
+    public static void AddAtiMetrics(this IServiceCollection services) => services.AddMetrics();
+
+    public static void AddMetrics(this IServiceCollection services)
     {
-        public static void AddMetrics(this IServiceCollection services)
-        {
-            services.ConfigureByName<MetricsOptions>();
-            services.AddTransient<MetricsInitializer>();
+        services.ConfigureByName<MetricsOptions>();
+        services.AddTransient<MetricsInitializer>();
             
-            InitializeExceptionsMetrics();
+        InitializeExceptionsMetrics();
 
-            MetricsLabelsAndHeaders.LabelsStatic = ConfigurationManager.GetSection(nameof(MetricsOptions))?.Get<MetricsOptions>()?.LabelsAndHeaders ?? new Dictionary<string, string>();
-            MetricsLabelsAndHeaders.UserLabels = MetricsLabelsAndHeaders.LabelsStatic.Keys.ToArray();
-            MetricsLabelsAndHeaders.UserHeaders = MetricsLabelsAndHeaders.LabelsStatic.Values.ToArray();
-        }
+        MetricsLabelsAndHeaders.LabelsStatic = ConfigurationManager.GetSection(nameof(MetricsOptions))?.Get<MetricsOptions>()?.LabelsAndHeaders ?? new Dictionary<string, string>();
+        MetricsLabelsAndHeaders.UserLabels = MetricsLabelsAndHeaders.LabelsStatic.Keys.ToArray();
+        MetricsLabelsAndHeaders.UserHeaders = MetricsLabelsAndHeaders.LabelsStatic.Values.ToArray();
+    }
 
-        private static void InitializeExceptionsMetrics()
-        {
-            var exceptionCollector = new ExceptionsMetricsCollector();
-            var registry = Prometheus.Metrics.DefaultRegistry;
+    private static void InitializeExceptionsMetrics()
+    {
+        var exceptionCollector = new ExceptionsMetricsCollector();
+        var registry = Prometheus.Metrics.DefaultRegistry;
             
-            exceptionCollector.RegisterMetrics(registry);
-            registry.AddBeforeCollectCallback(exceptionCollector.UpdateMetrics);
-        }
+        exceptionCollector.RegisterMetrics(registry);
+        registry.AddBeforeCollectCallback(exceptionCollector.UpdateMetrics);
+    }
 
-        public static void UseMetrics(this IApplicationBuilder app)
-        {
-            app.UseMiddleware<MetricsStatusCodeCounterMiddleware>();
-        }
+    public static void UseMetrics(this IApplicationBuilder app)
+    {
+        app.UseMiddleware<MetricsStatusCodeCounterMiddleware>();
     }
 }

--- a/ATI.Services.Common/Metrics/MetricsFactory.cs
+++ b/ATI.Services.Common/Metrics/MetricsFactory.cs
@@ -6,442 +6,438 @@ using ATI.Services.Common.Variables;
 using JetBrains.Annotations;
 using Prometheus;
 
-namespace ATI.Services.Common.Metrics
+namespace ATI.Services.Common.Metrics;
+
+[PublicAPI]
+public class MetricsFactory
 {
-    [PublicAPI]
-    public class MetricsFactory
+    private Summary Summary { get; }
+    public const string Prefix = "common_metric";
+    private static readonly string MachineName = Environment.MachineName;
+    private readonly string _className;
+    private readonly string _externalHttpServiceName;
+    private readonly LogSource _logSource;
+    private static TimeSpan _defaultLongRequestTime = TimeSpan.FromSeconds(1);
+
+    private static readonly QuantileEpsilonPair[] SummaryQuantileEpsilonPairs = {
+        new(0.5, 0.05),
+        new(0.9, 0.05),
+        new(0.95, 0.01),
+        new(0.99, 0.005),
+    };
+
+    //Время запроса считающегося достаточно долгим, что бы об этом доложить в кибану
+    private readonly TimeSpan _longRequestTime;
+
+    public static void Init(TimeSpan? defaultLongRequestTime = null)
     {
-        private Summary Summary { get; }
-        private static string _serviceName = "common_default";
-        private static readonly string MachineName = Environment.MachineName;
-        private readonly string _className;
-        private readonly string _externalHttpServiceName;
-        private readonly LogSource _logSource;
-        private static TimeSpan _defaultLongRequestTime = TimeSpan.FromSeconds(1);
-
-        private static readonly QuantileEpsilonPair[] SummaryQuantileEpsilonPairs = {
-            new(0.5, 0.05),
-            new(0.9, 0.05),
-            new(0.95, 0.01),
-            new(0.99, 0.005),
-        };
-
-        //Время запроса считающегося достаточно долгим, что бы об этом доложить в кибану
-        private readonly TimeSpan _longRequestTime;
-
-        public static void Init(string serviceName, TimeSpan? defaultLongRequestTime = null)
+        if (defaultLongRequestTime != null)
         {
-            if (serviceName != null)
-                _serviceName = $"common_{serviceName}";
-            
-            if (defaultLongRequestTime != null)
-            {
-                _defaultLongRequestTime = defaultLongRequestTime.Value;
-            }
+            _defaultLongRequestTime = defaultLongRequestTime.Value;
         }
+    }
 
-        public static MetricsFactory CreateHttpClientMetricsFactory(
-            [NotNull] string className,
-            string externalHttpServiceName,
-            TimeSpan? longRequestTime = null,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "route_template",
-                "entity_name",
-                "external_http_service_name",
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateHttpClientMetricsFactory(
+        [NotNull] string className,
+        string externalHttpServiceName,
+        TimeSpan? longRequestTime = null,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "route_template",
+            "entity_name",
+            "external_http_service_name",
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.HttpClient,
-                $"{_serviceName}_http_client",
-                externalHttpServiceName,
-                longRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.HttpClient,
+            $"{Prefix}_http_client",
+            externalHttpServiceName,
+            longRequestTime,
+            labels);
+    }
 
-        public static MetricsFactory CreateRedisMetricsFactory(
-            [NotNull] string className,
-            TimeSpan? longRequestTime = null,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "method_name",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateRedisMetricsFactory(
+        [NotNull] string className,
+        TimeSpan? longRequestTime = null,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "method_name",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.Redis,
-                $"{_serviceName}_redis",
-                longRequestTime ?? _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.Redis,
+            $"{Prefix}_redis",
+            longRequestTime ?? _defaultLongRequestTime,
+            labels);
+    }
 
-        public static MetricsFactory CreateMongoMetricsFactory(
-            [NotNull] string className,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "method_name",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateMongoMetricsFactory(
+        [NotNull] string className,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "method_name",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.Mongo,
-                $"{_serviceName}_mongo",
-                _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.Mongo,
+            $"{Prefix}_mongo",
+            _defaultLongRequestTime,
+            labels);
+    }
 
-        public static MetricsFactory CreateSqlMetricsFactory(
-            [NotNull] string className,
-            TimeSpan? longTimeRequest = null,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "procedure_name",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateSqlMetricsFactory(
+        [NotNull] string className,
+        TimeSpan? longTimeRequest = null,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "procedure_name",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.Sql,
-                $"{_serviceName}_sql",
-                _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.Sql,
+            $"{Prefix}_sql",
+            _defaultLongRequestTime,
+            labels);
+    }
 
-        public static MetricsFactory CreateControllerMetricsFactory(
-            [NotNull] string className,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "route_template",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateControllerMetricsFactory(
+        [NotNull] string className,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "route_template",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.Controller,
-                $"{_serviceName}_controller",
-                _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.Controller,
+            $"{Prefix}_controller",
+            _defaultLongRequestTime,
+            labels);
+    }
 
-        public static MetricsFactory CreateRepositoryMetricsFactory(
-            [NotNull] string className,
-            TimeSpan? requestLongTime = null,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "method_name",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateRepositoryMetricsFactory(
+        [NotNull] string className,
+        TimeSpan? requestLongTime = null,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "method_name",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.Repository,
-                $"{_serviceName}_repository",
-                requestLongTime ?? _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.Repository,
+            $"{Prefix}_repository",
+            requestLongTime ?? _defaultLongRequestTime,
+            labels);
+    }
         
-        public static MetricsFactory CreateRabbitMqMetricsFactory(
-            RabbitMetricsDirection direction,
-            [NotNull] string className,
-            TimeSpan? requestLongTime = null,
-            params string[] additionalSummaryLabels)
-        {
-            var labels = ConcatLabelNames(
-                "exchange_routing_key_name",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+    public static MetricsFactory CreateRabbitMqMetricsFactory(
+        RabbitMetricsDirection direction,
+        [NotNull] string className,
+        TimeSpan? requestLongTime = null,
+        params string[] additionalSummaryLabels)
+    {
+        var labels = ConcatLabelNames(
+            "exchange_routing_key_name",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.RabbitMq,
-                $"{_serviceName}_{direction.ToString().ToLower()}_rabbitmq",
-                requestLongTime ?? _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.RabbitMq,
+            $"{Prefix}_rabbitmq_{direction.ToString().ToLower()}",
+            requestLongTime ?? _defaultLongRequestTime,
+            labels);
+    }
         
-        public static MetricsFactory CreateCustomMetricsFactory(
-            [NotNull] string className,
-            string customMetricName,
-            TimeSpan? requestLongTime = null,
-            params string[] additionalSummaryLabels)
-        {
-            if(customMetricName is null) throw new ArgumentNullException(nameof(customMetricName));
+    public static MetricsFactory CreateCustomMetricsFactory(
+        [NotNull] string className,
+        string customMetricName,
+        TimeSpan? requestLongTime = null,
+        params string[] additionalSummaryLabels)
+    {
+        if(customMetricName is null) throw new ArgumentNullException(nameof(customMetricName));
             
-            var labels = ConcatLabelNames(
-                "method_name",
-                "entity_name",
-                null,
-                MetricsLabelsAndHeaders.UserLabels,
-                additionalSummaryLabels);
+        var labels = ConcatLabelNames(
+            "method_name",
+            "entity_name",
+            null,
+            MetricsLabelsAndHeaders.UserLabels,
+            additionalSummaryLabels);
 
-            return new MetricsFactory(
-                className,
-                LogSource.Custom,
-                $"{_serviceName}_{customMetricName}",
-                requestLongTime ?? _defaultLongRequestTime,
-                labels);
-        }
+        return new MetricsFactory(
+            className,
+            LogSource.Custom,
+            $"{Prefix}_{customMetricName}",
+            requestLongTime ?? _defaultLongRequestTime,
+            labels);
+    }
 
-        private MetricsFactory(
-            string className,
-            LogSource logSource,
-            string summaryServiceName,
-            string externalHttpServiceName,
-            TimeSpan? longRequestTime = null,
-            params string[] summaryLabelNames)
+    private MetricsFactory(
+        string className,
+        LogSource logSource,
+        string summaryServiceName,
+        string externalHttpServiceName,
+        TimeSpan? longRequestTime = null,
+        params string[] summaryLabelNames)
+    {
+        _className = className;
+        _externalHttpServiceName = externalHttpServiceName;
+        _longRequestTime = longRequestTime ?? _defaultLongRequestTime;
+        _logSource = logSource;
+
+        if (summaryServiceName != null)
         {
-            _className = className;
-            _externalHttpServiceName = externalHttpServiceName;
-            _longRequestTime = longRequestTime ?? _defaultLongRequestTime;
-            _logSource = logSource;
-
-            if (summaryServiceName != null)
+            var options = new SummaryConfiguration
             {
-                var options = new SummaryConfiguration
-                {
-                    MaxAge = TimeSpan.FromMinutes(1),
-                    Objectives = SummaryQuantileEpsilonPairs
-                };
-
-                Summary = Prometheus.Metrics.CreateSummary(
-                    summaryServiceName,
-                    string.Empty,
-                    summaryLabelNames,
-                    options);
-            }
-        }
-
-        private MetricsFactory(
-            string className,
-            LogSource logSource,
-            [CanBeNull] string summaryServiceName,
-            TimeSpan longRequestTime,
-            params string[] summaryLabelNames)
-        {
-            _className = className;
-            _longRequestTime = longRequestTime;
-            _logSource = logSource;
-
-            if (summaryServiceName != null)
-            {
-                var options = new SummaryConfiguration
-                {
-                    MaxAge = TimeSpan.FromMinutes(1),
-                    Objectives = SummaryQuantileEpsilonPairs
-                };
-
-                Summary = Prometheus.Metrics.CreateSummary(
-                    summaryServiceName,
-                    string.Empty,
-                    summaryLabelNames,
-                    options);
-            }
-        }
-
-        public IDisposable CreateMetricsTimerWithLogging(
-            string entityName,
-            [CallerMemberName] string actionName = null,
-            object requestParams = null,
-            TimeSpan? longRequestTime = null,
-            params string[] additionalLabels)
-        {
-            if (Summary == null)
-            {
-                throw new NullReferenceException($"{nameof(Summary)} is not initialized");
-            }
-
-            var labels = ConcatLabelValues(
-                _className,
-                actionName,
-                entityName,
-                _externalHttpServiceName,
-                AppHttpContext.MetricsHeadersValues,
-                additionalLabels);
-
-            return new MetricsTimer(
-                Summary,
-                labels,
-                longRequestTime ?? _longRequestTime,
-                requestParams,
-                _logSource);
-        }
-
-        /// <summary>
-        /// В случае создания данного экземпляра таймер для метрик стартует не сразу, а только после вызова метода Restart()
-        /// </summary>
-        /// <param name="entityName"></param>
-        /// <param name="actionName"></param>
-        /// <param name="requestParams"></param>
-        /// <param name="longRequestTime"></param>
-        /// <param name="additionalLabels"></param>
-        /// <returns></returns>
-        /// <exception cref="NullReferenceException"></exception>
-        public MetricsTimer CreateMetricsTimerWithDelayedLogging(
-            string entityName,
-            [CallerMemberName] string actionName = null,
-            object requestParams = null,
-            TimeSpan? longRequestTime = null,
-            params string[] additionalLabels)
-        {
-            if (Summary == null)
-            {
-                throw new NullReferenceException($"{nameof(Summary)} is not initialized");
-            }
-
-            var labels = ConcatLabelValues(
-                _className,
-                actionName,
-                entityName,
-                _externalHttpServiceName,
-                AppHttpContext.MetricsHeadersValues,
-                additionalLabels);
-
-            return new MetricsTimer(
-                Summary,
-                labels,
-                longRequestTime ?? _longRequestTime,
-                requestParams,
-                _logSource,
-                false);
-        }
-
-        public IDisposable CreateLoggingMetricsTimer(
-            string entityName,
-            [CallerMemberName] string actionName = null,
-            object requestParams = null,
-            TimeSpan? longRequestTime = null,
-            params string[] additionalLabels)
-        {
-            var labels = ConcatLabelValues(
-                _className,
-                actionName,
-                entityName,
-                _externalHttpServiceName,
-                AppHttpContext.MetricsHeadersValues,
-                additionalLabels);
-
-            return new MetricsTimer(
-                Summary,
-                labels,
-                longRequestTime ?? _longRequestTime,
-                requestParams,
-                _logSource);
-        }
-
-        public IDisposable CreateMetricsTimer(
-            string entityName,
-            [CallerMemberName] string actionName = null,
-            params string[] additionalLabels)
-        {
-            var labels = ConcatLabelValues(
-                _className,
-                actionName,
-                entityName,
-                _externalHttpServiceName,
-                AppHttpContext.MetricsHeadersValues,
-                additionalLabels);
-
-            return new MetricsTimer(Summary, labels);
-        }
-
-        /// <summary>
-        /// Метод управляющий порядком значений лэйблов 
-        /// </summary>
-        private static string[] ConcatLabelValues(
-            string className,
-            string actionName,
-            string entityName = null,
-            string externHttpService = null,
-            string[] userLabels = null,
-            params string[] additionalLabels)
-        {
-            return ConcatLabels(
-                className,
-                MachineName,
-                actionName,
-                entityName,
-                externHttpService,
-                userLabels,
-                additionalLabels);
-        }
-
-        /// <summary>
-        /// Метод управляющий порядком названий лэйблов
-        /// </summary>
-        private static string[] ConcatLabelNames(
-            string actionName,
-            string entityName = null,
-            string externHttpService = null,
-            string[] userLabels = null,
-            params string[] additionalLabels)
-        {
-            return ConcatLabels(
-                "class_name",
-                "machine_name",
-                actionName,
-                entityName,
-                externHttpService,
-                userLabels,
-                additionalLabels);
-        }
-
-        /// <summary>
-        /// Метод управляющий порядком лэйблов и их значений
-        /// <param name="actionName"> Указывать только при объявлении лейблов. Записывается он в таймере, так как нужен для трейсинга</param>
-        /// </summary>
-        private static string[] ConcatLabels(
-            string className,
-            string machineName,
-            string actionName,
-            string entityName,
-            string externHttpService,
-            string[] userLabels,
-            params string[] additionalLabels)
-        {
-            var labels = new List<string>
-            {
-                className,
-                actionName
+                MaxAge = TimeSpan.FromMinutes(1),
+                Objectives = SummaryQuantileEpsilonPairs
             };
-            
-            if (machineName != null)
-                labels.Add(machineName);
 
-            if (entityName != null)
-                labels.Add(entityName);
-
-            if (externHttpService != null)
-                labels.Add(externHttpService);
-
-            if (userLabels != null && userLabels.Length != 0)
-                labels.AddRange(userLabels);
-
-            if (additionalLabels.Length != 0)
-                labels.AddRange(additionalLabels);
-
-            return labels.ToArray();
+            Summary = Prometheus.Metrics.CreateSummary(
+                summaryServiceName,
+                string.Empty,
+                summaryLabelNames,
+                options);
         }
+    }
+
+    private MetricsFactory(
+        string className,
+        LogSource logSource,
+        [CanBeNull] string summaryServiceName,
+        TimeSpan longRequestTime,
+        params string[] summaryLabelNames)
+    {
+        _className = className;
+        _longRequestTime = longRequestTime;
+        _logSource = logSource;
+
+        if (summaryServiceName != null)
+        {
+            var options = new SummaryConfiguration
+            {
+                MaxAge = TimeSpan.FromMinutes(1),
+                Objectives = SummaryQuantileEpsilonPairs
+            };
+
+            Summary = Prometheus.Metrics.CreateSummary(
+                summaryServiceName,
+                string.Empty,
+                summaryLabelNames,
+                options);
+        }
+    }
+
+    public IDisposable CreateMetricsTimerWithLogging(
+        string entityName,
+        [CallerMemberName] string actionName = null,
+        object requestParams = null,
+        TimeSpan? longRequestTime = null,
+        params string[] additionalLabels)
+    {
+        if (Summary == null)
+        {
+            throw new NullReferenceException($"{nameof(Summary)} is not initialized");
+        }
+
+        var labels = ConcatLabelValues(
+            _className,
+            actionName,
+            entityName,
+            _externalHttpServiceName,
+            AppHttpContext.MetricsHeadersValues,
+            additionalLabels);
+
+        return new MetricsTimer(
+            Summary,
+            labels,
+            longRequestTime ?? _longRequestTime,
+            requestParams,
+            _logSource);
+    }
+
+    /// <summary>
+    /// В случае создания данного экземпляра таймер для метрик стартует не сразу, а только после вызова метода Restart()
+    /// </summary>
+    /// <param name="entityName"></param>
+    /// <param name="actionName"></param>
+    /// <param name="requestParams"></param>
+    /// <param name="longRequestTime"></param>
+    /// <param name="additionalLabels"></param>
+    /// <returns></returns>
+    /// <exception cref="NullReferenceException"></exception>
+    public MetricsTimer CreateMetricsTimerWithDelayedLogging(
+        string entityName,
+        [CallerMemberName] string actionName = null,
+        object requestParams = null,
+        TimeSpan? longRequestTime = null,
+        params string[] additionalLabels)
+    {
+        if (Summary == null)
+        {
+            throw new NullReferenceException($"{nameof(Summary)} is not initialized");
+        }
+
+        var labels = ConcatLabelValues(
+            _className,
+            actionName,
+            entityName,
+            _externalHttpServiceName,
+            AppHttpContext.MetricsHeadersValues,
+            additionalLabels);
+
+        return new MetricsTimer(
+            Summary,
+            labels,
+            longRequestTime ?? _longRequestTime,
+            requestParams,
+            _logSource,
+            false);
+    }
+
+    public IDisposable CreateLoggingMetricsTimer(
+        string entityName,
+        [CallerMemberName] string actionName = null,
+        object requestParams = null,
+        TimeSpan? longRequestTime = null,
+        params string[] additionalLabels)
+    {
+        var labels = ConcatLabelValues(
+            _className,
+            actionName,
+            entityName,
+            _externalHttpServiceName,
+            AppHttpContext.MetricsHeadersValues,
+            additionalLabels);
+
+        return new MetricsTimer(
+            Summary,
+            labels,
+            longRequestTime ?? _longRequestTime,
+            requestParams,
+            _logSource);
+    }
+
+    public IDisposable CreateMetricsTimer(
+        string entityName,
+        [CallerMemberName] string actionName = null,
+        params string[] additionalLabels)
+    {
+        var labels = ConcatLabelValues(
+            _className,
+            actionName,
+            entityName,
+            _externalHttpServiceName,
+            AppHttpContext.MetricsHeadersValues,
+            additionalLabels);
+
+        return new MetricsTimer(Summary, labels);
+    }
+
+    /// <summary>
+    /// Метод управляющий порядком значений лэйблов 
+    /// </summary>
+    private static string[] ConcatLabelValues(
+        string className,
+        string actionName,
+        string entityName = null,
+        string externHttpService = null,
+        string[] userLabels = null,
+        params string[] additionalLabels)
+    {
+        return ConcatLabels(
+            className,
+            MachineName,
+            actionName,
+            entityName,
+            externHttpService,
+            userLabels,
+            additionalLabels);
+    }
+
+    /// <summary>
+    /// Метод управляющий порядком названий лэйблов
+    /// </summary>
+    private static string[] ConcatLabelNames(
+        string actionName,
+        string entityName = null,
+        string externHttpService = null,
+        string[] userLabels = null,
+        params string[] additionalLabels)
+    {
+        return ConcatLabels(
+            "class_name",
+            "machine_name",
+            actionName,
+            entityName,
+            externHttpService,
+            userLabels,
+            additionalLabels);
+    }
+
+    /// <summary>
+    /// Метод управляющий порядком лэйблов и их значений
+    /// <param name="actionName"> Указывать только при объявлении лейблов. Записывается он в таймере, так как нужен для трейсинга</param>
+    /// </summary>
+    private static string[] ConcatLabels(
+        string className,
+        string machineName,
+        string actionName,
+        string entityName,
+        string externHttpService,
+        string[] userLabels,
+        params string[] additionalLabels)
+    {
+        var labels = new List<string>
+        {
+            className,
+            actionName
+        };
+            
+        if (machineName != null)
+            labels.Add(machineName);
+
+        if (entityName != null)
+            labels.Add(entityName);
+
+        if (externHttpService != null)
+            labels.Add(externHttpService);
+
+        if (userLabels != null && userLabels.Length != 0)
+            labels.AddRange(userLabels);
+
+        if (additionalLabels.Length != 0)
+            labels.AddRange(additionalLabels);
+
+        return labels.ToArray();
     }
 }

--- a/ATI.Services.Common/Metrics/MetricsFactory.cs
+++ b/ATI.Services.Common/Metrics/MetricsFactory.cs
@@ -44,7 +44,7 @@ public class MetricsFactory
         params string[] additionalSummaryLabels)
     {
         var labels = ConcatLabelNames(
-            "route_template",
+            "route_template",    
             "entity_name",
             "external_http_service_name",
             MetricsLabelsAndHeaders.UserLabels,
@@ -158,7 +158,7 @@ public class MetricsFactory
     }
         
     public static MetricsFactory CreateRabbitMqMetricsFactory(
-        RabbitMetricsDirection direction,
+        RabbitMetricsType type,
         [NotNull] string className,
         TimeSpan? requestLongTime = null,
         params string[] additionalSummaryLabels)
@@ -173,7 +173,7 @@ public class MetricsFactory
         return new MetricsFactory(
             className,
             LogSource.RabbitMq,
-            $"{Prefix}_rabbitmq_{direction.ToString().ToLower()}",
+            $"{Prefix}_rabbitmq_{type.ToString().ToLower()}",
             requestLongTime ?? _defaultLongRequestTime,
             labels);
     }

--- a/ATI.Services.Common/Metrics/MetricsFactory.cs
+++ b/ATI.Services.Common/Metrics/MetricsFactory.cs
@@ -159,6 +159,50 @@ namespace ATI.Services.Common.Metrics
                 requestLongTime ?? _defaultLongRequestTime,
                 labels);
         }
+        
+        public static MetricsFactory CreateRabbitMqMetricsFactory(
+            RabbitMetricsDirection direction,
+            [NotNull] string className,
+            TimeSpan? requestLongTime = null,
+            params string[] additionalSummaryLabels)
+        {
+            var labels = ConcatLabelNames(
+                "exchange_routing_key_name",
+                "entity_name",
+                null,
+                MetricsLabelsAndHeaders.UserLabels,
+                additionalSummaryLabels);
+
+            return new MetricsFactory(
+                className,
+                LogSource.RabbitMq,
+                $"{_serviceName}_{direction.ToString().ToLower()}_rabbitmq",
+                requestLongTime ?? _defaultLongRequestTime,
+                labels);
+        }
+        
+        public static MetricsFactory CreateCustomMetricsFactory(
+            [NotNull] string className,
+            string customMetricName,
+            TimeSpan? requestLongTime = null,
+            params string[] additionalSummaryLabels)
+        {
+            if(customMetricName is null) throw new ArgumentNullException(nameof(customMetricName));
+            
+            var labels = ConcatLabelNames(
+                "method_name",
+                "entity_name",
+                null,
+                MetricsLabelsAndHeaders.UserLabels,
+                additionalSummaryLabels);
+
+            return new MetricsFactory(
+                className,
+                LogSource.Custom,
+                $"{_serviceName}_{customMetricName}",
+                requestLongTime ?? _defaultLongRequestTime,
+                labels);
+        }
 
         private MetricsFactory(
             string className,

--- a/ATI.Services.Common/Metrics/MetricsFactory.cs
+++ b/ATI.Services.Common/Metrics/MetricsFactory.cs
@@ -54,7 +54,7 @@ namespace ATI.Services.Common.Metrics
             return new MetricsFactory(
                 className,
                 LogSource.HttpClient,
-                $"{_serviceName}.http_client",
+                $"{_serviceName}_http_client",
                 externalHttpServiceName,
                 longRequestTime,
                 labels);
@@ -75,7 +75,7 @@ namespace ATI.Services.Common.Metrics
             return new MetricsFactory(
                 className,
                 LogSource.Redis,
-                $"{_serviceName}.redis",
+                $"{_serviceName}_redis",
                 longRequestTime ?? _defaultLongRequestTime,
                 labels);
         }
@@ -94,7 +94,7 @@ namespace ATI.Services.Common.Metrics
             return new MetricsFactory(
                 className,
                 LogSource.Mongo,
-                $"{_serviceName}.mongo",
+                $"{_serviceName}_mongo",
                 _defaultLongRequestTime,
                 labels);
         }
@@ -114,7 +114,7 @@ namespace ATI.Services.Common.Metrics
             return new MetricsFactory(
                 className,
                 LogSource.Sql,
-                $"{_serviceName}.sql",
+                $"{_serviceName}_sql",
                 _defaultLongRequestTime,
                 labels);
         }
@@ -133,7 +133,7 @@ namespace ATI.Services.Common.Metrics
             return new MetricsFactory(
                 className,
                 LogSource.Controller,
-                $"{_serviceName}.controller",
+                $"{_serviceName}_controller",
                 _defaultLongRequestTime,
                 labels);
         }
@@ -153,7 +153,7 @@ namespace ATI.Services.Common.Metrics
             return new MetricsFactory(
                 className,
                 LogSource.Repository,
-                $"{_serviceName}.repository",
+                $"{_serviceName}_repository",
                 requestLongTime ?? _defaultLongRequestTime,
                 labels);
         }

--- a/ATI.Services.Common/Metrics/MetricsFactory.cs
+++ b/ATI.Services.Common/Metrics/MetricsFactory.cs
@@ -12,7 +12,7 @@ namespace ATI.Services.Common.Metrics
     public class MetricsFactory
     {
         private Summary Summary { get; }
-        private static string _serviceName = "default_name";
+        private static string _serviceName = "common_default";
         private static readonly string MachineName = Environment.MachineName;
         private readonly string _className;
         private readonly string _externalHttpServiceName;
@@ -31,7 +31,9 @@ namespace ATI.Services.Common.Metrics
 
         public static void Init(string serviceName, TimeSpan? defaultLongRequestTime = null)
         {
-            _serviceName = serviceName;
+            if (serviceName != null)
+                _serviceName = $"common_{serviceName}";
+            
             if (defaultLongRequestTime != null)
             {
                 _defaultLongRequestTime = defaultLongRequestTime.Value;

--- a/ATI.Services.Common/Metrics/MetricsOptions.cs
+++ b/ATI.Services.Common/Metrics/MetricsOptions.cs
@@ -1,22 +1,16 @@
 using System;
 using System.Collections.Generic;
 
-namespace ATI.Services.Common.Metrics
+namespace ATI.Services.Common.Metrics;
+
+public class MetricsOptions
 {
-    public class MetricsOptions
-    {
-        /// <summary>
-        /// User's additional labels and headers
-        /// Keys are labels' names
-        /// Values are headers' names
-        /// </summary>
-        public Dictionary<string, string> LabelsAndHeaders { get; set; }
+    /// <summary>
+    /// User's additional labels and headers
+    /// Keys are labels' names
+    /// Values are headers' names
+    /// </summary>
+    public Dictionary<string, string> LabelsAndHeaders { get; set; }
         
-        public TimeSpan? DefaultLongRequestTime { get; set; }
-        
-        /// <summary>
-        /// Название сервиса для метрик, без точек и прочих символов
-        /// </summary>
-        public string MetricsServiceName { get; set; }
-    }
+    public TimeSpan? DefaultLongRequestTime { get; set; }
 }

--- a/ATI.Services.Common/Metrics/MetricsStatusCodeCounterMiddleware.cs
+++ b/ATI.Services.Common/Metrics/MetricsStatusCodeCounterMiddleware.cs
@@ -4,6 +4,8 @@ using ATI.Services.Common.Variables;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Prometheus;
+using ConfigurationManager = ATI.Services.Common.Behaviors.ConfigurationManager;
+
 
 namespace ATI.Services.Common.Metrics;
 
@@ -13,10 +15,10 @@ public class MetricsStatusCodeCounterMiddleware
 
     private readonly RequestDelegate _next;
 
-    public MetricsStatusCodeCounterMiddleware(RequestDelegate next, IConfiguration configuration)
+    public MetricsStatusCodeCounterMiddleware(RequestDelegate next)
     {
-        var prefix = configuration.GetSection(nameof(MetricsOptions))
-                                  .Get<MetricsOptions>().MetricsServiceName is { } serviceName
+        var prefix = ConfigurationManager.GetSection(nameof(MetricsOptions))
+                                         ?.Get<MetricsOptions>()?.MetricsServiceName is { } serviceName
                          ? $"common_{serviceName}"
                          : "common_default";
 

--- a/ATI.Services.Common/Metrics/MetricsStatusCodeCounterMiddleware.cs
+++ b/ATI.Services.Common/Metrics/MetricsStatusCodeCounterMiddleware.cs
@@ -2,27 +2,18 @@
 using System.Threading.Tasks;
 using ATI.Services.Common.Variables;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Prometheus;
-using ConfigurationManager = ATI.Services.Common.Behaviors.ConfigurationManager;
-
 
 namespace ATI.Services.Common.Metrics;
 
 public class MetricsStatusCodeCounterMiddleware
 {
     private readonly Counter _counter;
-
     private readonly RequestDelegate _next;
 
     public MetricsStatusCodeCounterMiddleware(RequestDelegate next)
     {
-        var prefix = ConfigurationManager.GetSection(nameof(MetricsOptions))
-                                         ?.Get<MetricsOptions>()?.MetricsServiceName is { } serviceName
-                         ? $"common_{serviceName}"
-                         : "common_default";
-
-        _counter = Prometheus.Metrics.CreateCounter($"{prefix}_HttpStatusCodeCounter",
+        _counter = Prometheus.Metrics.CreateCounter($"{MetricsFactory.Prefix}_HttpStatusCodeCounter",
                                                     "",
                                                     new CounterConfiguration
                                                     {

--- a/ATI.Services.Common/Metrics/RabbitMetricsDirection.cs
+++ b/ATI.Services.Common/Metrics/RabbitMetricsDirection.cs
@@ -1,0 +1,7 @@
+﻿namespace ATI.Services.Common.Metrics;
+
+public enum RabbitMetricsDirection
+{
+    In,
+    Out
+}

--- a/ATI.Services.Common/Metrics/RabbitMetricsDirection.cs
+++ b/ATI.Services.Common/Metrics/RabbitMetricsDirection.cs
@@ -1,7 +1,0 @@
-﻿namespace ATI.Services.Common.Metrics;
-
-public enum RabbitMetricsDirection
-{
-    In,
-    Out
-}

--- a/ATI.Services.Common/Metrics/RabbitMetricsType.cs
+++ b/ATI.Services.Common/Metrics/RabbitMetricsType.cs
@@ -1,0 +1,7 @@
+﻿namespace ATI.Services.Common.Metrics;
+
+public enum RabbitMetricsType
+{
+    Subscribe,
+    Publish
+}

--- a/ATI.Services.Common/Sql/DapperDb.cs
+++ b/ATI.Services.Common/Sql/DapperDb.cs
@@ -1019,6 +1019,8 @@ namespace ATI.Services.Common.Sql
                 builder.ConnectRetryInterval = _options.ConnectRetryInterval.Value;
             }
 
+            builder.TrustServerCertificate = _options.TrustServerCertificate ?? true;
+
             return builder.ToString();
         }
 

--- a/ATI.Services.Common/Sql/DataBaseOptions.cs
+++ b/ATI.Services.Common/Sql/DataBaseOptions.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ATI.Services.Common.Sql
+namespace ATI.Services.Common.Sql;
+
+public class DataBaseOptions
 {
-   public class DataBaseOptions
-    {
-        public string ConnectionString { get; set; }
-        public TimeSpan Timeout { get; set; }
-        public IDictionary<string, int> TimeoutDictionary { get; set; } = new Dictionary<string, int>();
-        public TimeSpan? LongTimeRequest { get; set; }
+    public string ConnectionString { get; set; }
+    public TimeSpan Timeout { get; set; }
+    public IDictionary<string, int> TimeoutDictionary { get; set; } = new Dictionary<string, int>();
+    public TimeSpan? LongTimeRequest { get; set; }
         
-        public string Server { get; set; }
-        public string Database { get; set; }
-        public string UserName { get; set; }
-        public string Password { get; set; }
-        public int? MinPoolSize { get; set; }
-        public int? MaxPoolSize { get; set; }
-        public int? ConnectTimeout { get; set; }
-        public int? ConnectRetryCount { get; set; }
-        public int? ConnectRetryInterval { get; set; }
-    }
+    public string Server { get; set; }
+    public string Database { get; set; }
+    public string UserName { get; set; }
+    public string Password { get; set; }
+    public int? MinPoolSize { get; set; }
+    public int? MaxPoolSize { get; set; }
+    public int? ConnectTimeout { get; set; }
+    public int? ConnectRetryCount { get; set; }
+    public int? ConnectRetryInterval { get; set; }
+    public bool? TrustServerCertificate { get; set; }
 }


### PR DESCRIPTION
## Changes
- removed `MetricsServiceName` and `summaryName`(class name) from metric's name, also removed `MetricsServiceName` from `MetricsOptions`
- now metrics has common prefix `common_metric_`
- two new factory methods added for RabbitMq and Custom
- removed factory method for ExternalHttpClient - it didn't worked and used only in `MetricsHtttpClientWrapper`
- removed metric collection from `MetricsHtttpClientWrapper`, it didn't worked;
adding metrics to `MetricsHtttpClientWrapper` requires passing urlTemplate, serviceName and possibility to disable them, otherwise it duplicates metrics from `ConsulMetricsHttpClientWrapper`
- added new extension method `AddAtiMetrics` - alias for `AddMetrics`, cause this one conflicts with `Microsoft.Extensions.DependencyInjection.MetricsServiceExtensions.AddMetrics` starting .net7
- removed client-header-name from controller metrics, it was temporary fallback in case of absence `X-Client-Name` header
- removed LangVersion, now it's bound to dotnet version
- updated prometheus-net to v8.2.1 due to [bug](https://github.com/prometheus-net/prometheus-net/releases/tag/v8.1.1) that was fixed in v8.1.1
- updated Microsoft.Data.SqlClient to v5.2.0 due to [bug](https://github.com/dotnet/SqlClient/issues/1930)
- updated setting TrustServerCertificate in sql connection string is ignored and is true by default, could be overriden through DataBaseOptions

## Comparison with previous
For example previous http metrics:  
- `default_nameXzibitServiceAdapter{}`
- `default_nameAuthorizationAdapter{}` 
- `default_nameMarshakAdapter{}` and so on  

Became one metric: `common_metric_http_client{__name__ = "class_name_here"}`

## New metrics list
```
common_metric_sql 
common_metric_http_client - for outgoing http requests, ConsulMetricsHttpClientWrapper uses it
common_metric_rabbitmq_in - incoming messages from rmq, used by ATI.Services.RabbitMQ and ChangeTracking
common_metric_rabbitmq_out - outgoing messages to rmq
common_metric_repository
common_metric_controller - incoming http requests, added by MeasureAttribute
common_metric_Exceptions
common_metric_HttpStatusCodeCounter - response codes
common_metric_redis
common_metric_mongo
common_metric_{something} - this one reserved for custom metric, if you really need it, try to keep number of unique metrics as low as possible
```
