### PR TITLE
IInitializerTimeout and message to ErrorWithObject overload

### DIFF
--- a/ATI.Services.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/ATI.Services.Common/Extensions/ServiceCollectionExtensions.cs
@@ -1,40 +1,29 @@
 ﻿using System;
-using System.Threading.Tasks;
 using ATI.Services.Common.Initializers;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ConfigurationManager = ATI.Services.Common.Behaviors.ConfigurationManager;
 
-namespace ATI.Services.Common.Extensions;
-
-public static class ServiceCollectionExtensions
+namespace ATI.Services.Common.Extensions
 {
-    public static void ConfigureByName<T>(this IServiceCollection serviceCollection, bool checkSectionExists = true)
-        where T : class
+    public static class ServiceCollectionExtensions
     {
-        var sectionName = typeof(T).Name;
+        public static void ConfigureByName<T>(this IServiceCollection serviceCollection, bool checkSectionExists = true)
+            where T : class
+        {
+            var sectionName = typeof(T).Name;
             
-        var section = ConfigurationManager.GetSection(sectionName);
-        // Если секции не существует - что-то забыли. Бросаем эксепшн при старте приложения
-        if(checkSectionExists && !section.Exists())
-            throw new Exception($"Секции {sectionName} нет в appsettings.json");
+            var section = ConfigurationManager.GetSection(sectionName);
+            // Если секции не существует - что-то забыли. Бросаем эксепшн при старте приложения
+            if(checkSectionExists && !section.Exists())
+                throw new Exception($"Секции {sectionName} нет в appsettings.json");
             
-        serviceCollection.Configure<T>(section);
-    }
+            serviceCollection.Configure<T>(section);
+        }
 
-    [UsedImplicitly]
-    public static IServiceCollection AddInitializers(this IServiceCollection services)
-        => services.AddTransient<StartupInitializer>();
-        
-    [UsedImplicitly]
-    public static async Task<IApplicationBuilder> UseInitializers(this IApplicationBuilder app)
-    {
-        var startupInitializer = app.ApplicationServices.GetRequiredService<StartupInitializer>();
-
-        await startupInitializer.InitializeAsync();
-            
-        return app;
+        [UsedImplicitly]
+        public static IServiceCollection AddInitializers(this IServiceCollection services)
+            => services.AddTransient<StartupInitializer>();
     }
 }

--- a/ATI.Services.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/ATI.Services.Common/Extensions/ServiceCollectionExtensions.cs
@@ -1,29 +1,40 @@
 ﻿using System;
+using System.Threading.Tasks;
 using ATI.Services.Common.Initializers;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ConfigurationManager = ATI.Services.Common.Behaviors.ConfigurationManager;
 
-namespace ATI.Services.Common.Extensions
-{
-    public static class ServiceCollectionExtensions
-    {
-        public static void ConfigureByName<T>(this IServiceCollection serviceCollection, bool checkSectionExists = true)
-            where T : class
-        {
-            var sectionName = typeof(T).Name;
-            
-            var section = ConfigurationManager.GetSection(sectionName);
-            // Если секции не существует - что-то забыли. Бросаем эксепшн при старте приложения
-            if(checkSectionExists && !section.Exists())
-                throw new Exception($"Секции {sectionName} нет в appsettings.json");
-            
-            serviceCollection.Configure<T>(section);
-        }
+namespace ATI.Services.Common.Extensions;
 
-        [UsedImplicitly]
-        public static IServiceCollection AddInitializers(this IServiceCollection services)
-            => services.AddTransient<StartupInitializer>();
+public static class ServiceCollectionExtensions
+{
+    public static void ConfigureByName<T>(this IServiceCollection serviceCollection, bool checkSectionExists = true)
+        where T : class
+    {
+        var sectionName = typeof(T).Name;
+            
+        var section = ConfigurationManager.GetSection(sectionName);
+        // Если секции не существует - что-то забыли. Бросаем эксепшн при старте приложения
+        if(checkSectionExists && !section.Exists())
+            throw new Exception($"Секции {sectionName} нет в appsettings.json");
+            
+        serviceCollection.Configure<T>(section);
+    }
+
+    [UsedImplicitly]
+    public static IServiceCollection AddInitializers(this IServiceCollection services)
+        => services.AddTransient<StartupInitializer>();
+        
+    [UsedImplicitly]
+    public static async Task<IApplicationBuilder> UseInitializers(this IApplicationBuilder app)
+    {
+        var startupInitializer = app.ApplicationServices.GetRequiredService<StartupInitializer>();
+
+        await startupInitializer.InitializeAsync();
+            
+        return app;
     }
 }

--- a/ATI.Services.Common/Initializers/InitializeOrderAttribute.cs
+++ b/ATI.Services.Common/Initializers/InitializeOrderAttribute.cs
@@ -1,10 +1,9 @@
 using System;
 
-namespace ATI.Services.Common.Initializers
+namespace ATI.Services.Common.Initializers;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class InitializeOrderAttribute : Attribute
 {
-    [AttributeUsage(AttributeTargets.Class)]
-    public class InitializeOrderAttribute : Attribute
-    {
-        public InitializeOrder Order { get; set; }
-    }
+    public InitializeOrder Order { get; set; }
 }

--- a/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
+++ b/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
@@ -2,16 +2,24 @@
 
 namespace ATI.Services.Common.Initializers;
 
+/// <summary>
+/// Attribute for setting initialization timeout and behavior in case of timeout
+/// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class InitializeTimeoutAttribute : Attribute
 {
     /// <summary>
-    /// Initialization timeout in seconds 
+    /// Initialization timeout in seconds
+    /// When set, enables timeout for initialization,
+    /// in case of Timeout and Required = true, application will not start
+    /// in case of Timeout and Required = false, application will start without waiting for initialization if this service
+    /// Default value is 10 seconds 
     /// </summary>
     public int InitTimeoutSec { get; set; } = 10;
+    
     /// <summary>
     /// Is initialization required
-    /// 
+    /// When true, application will not start if initialization failed due to timeout or exception
     /// </summary>
     public bool Required { get; set; } = false;
 }

--- a/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
+++ b/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
@@ -9,13 +9,18 @@ namespace ATI.Services.Common.Initializers;
 public class InitializeTimeoutAttribute : Attribute
 {
     /// <summary>
-    /// Initialization timeout in seconds
+    /// Total initialization timeout in seconds
     /// When set, enables timeout for initialization,
     /// in case of Timeout and Required = true, application will not start
     /// in case of Timeout and Required = false, application will start without waiting for initialization if this service
     /// Default value is 10 seconds 
     /// </summary>
     public int InitTimeoutSec { get; set; } = 10;
+
+    /// <summary>
+    /// Number of retries on exception
+    /// </summary>
+    public int Retry { get; set; } = 0;
     
     /// <summary>
     /// Is initialization required

--- a/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
+++ b/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
@@ -5,6 +5,13 @@ namespace ATI.Services.Common.Initializers;
 [AttributeUsage(AttributeTargets.Class)]
 public class InitializeTimeoutAttribute : Attribute
 {
-    public TimeSpan InitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    /// <summary>
+    /// Initialization timeout in seconds 
+    /// </summary>
+    public int InitTimeoutSec { get; set; } = 10;
+    /// <summary>
+    /// Is initialization required
+    /// 
+    /// </summary>
     public bool Required { get; set; } = false;
 }

--- a/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
+++ b/ATI.Services.Common/Initializers/InitializeTimeoutAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace ATI.Services.Common.Initializers;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class InitializeTimeoutAttribute : Attribute
+{
+    public TimeSpan InitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public bool Required { get; set; } = false;
+}

--- a/ATI.Services.Common/Initializers/Interfaces/IInitializer.cs
+++ b/ATI.Services.Common/Initializers/Interfaces/IInitializer.cs
@@ -1,26 +1,24 @@
 using System.Threading.Tasks;
 using ATI.Services.Common.Variables;
 
-namespace ATI.Services.Common.Initializers.Interfaces
-{
-    /// <summary>
-    /// Интерфейс который маркирует объект, как требующий инициализации на старте приложения
-    /// используется классом <see cref="StartupInitializer"/>
-    /// для задания порядка инициализации используйте аттрибут <see cref="InitializeOrderAttribute"/>
-    /// Имеющийся порядок на данный момент:
-    /// ATI.Services.Authorization.AuthorizationInitializer - InitializeOrder.First
-    /// <see cref="ServiceVariablesInitializer"/> -  InitializeOrder.First
-    /// <see cref="MetricsInitializer"/> -  InitializeOrder.First
-    /// <see cref="RedisInitializer"/> -  InitializeOrder.Third
-    /// <see cref="TwoLevelCacheInitializer"/> -  InitializeOrder.Third
-    /// <see cref="Caching.LocalCache.LocalCache{T}"/> -  InitializeOrder.Fourth
-    /// ATI.Services.Consul.ConsulInitializer -  InitializeOrder.Sixth
-    /// </summary>
-    public interface IInitializer
-    { 
-        Task InitializeAsync();
-        string InitStartConsoleMessage();
-        string InitEndConsoleMessage();
-        
-    }
+ namespace ATI.Services.Common.Initializers.Interfaces;
+
+/// <summary>
+/// Интерфейс который маркирует объект, как требующий инициализации на старте приложения
+/// используется классом <see cref="StartupInitializer"/>
+/// для задания порядка инициализации используйте аттрибут <see cref="InitializeOrderAttribute"/>
+/// Имеющийся порядок на данный момент:
+/// ATI.Services.Authorization.AuthorizationInitializer - InitializeOrder.First
+/// <see cref="ServiceVariablesInitializer"/> -  InitializeOrder.First
+/// <see cref="MetricsInitializer"/> -  InitializeOrder.First
+/// <see cref="RedisInitializer"/> -  InitializeOrder.Third
+/// <see cref="TwoLevelCacheInitializer"/> -  InitializeOrder.Third
+/// <see cref="Caching.LocalCache.LocalCache{T}"/> -  InitializeOrder.Fourth
+/// ATI.Services.Consul.ConsulInitializer -  InitializeOrder.Sixth
+/// </summary>
+public interface IInitializer
+{ 
+    Task InitializeAsync();
+    string InitStartConsoleMessage();
+    string InitEndConsoleMessage();
 }

--- a/ATI.Services.Common/Initializers/Interfaces/IInitializer.cs
+++ b/ATI.Services.Common/Initializers/Interfaces/IInitializer.cs
@@ -6,6 +6,7 @@ using ATI.Services.Common.Variables;
 /// <summary>
 /// Интерфейс который маркирует объект, как требующий инициализации на старте приложения
 /// используется классом <see cref="StartupInitializer"/>
+/// <para>Для управления временем и поведением инициацлизации используйте <see cref="InitializeTimeoutAttribute"/></para>
 /// для задания порядка инициализации используйте аттрибут <see cref="InitializeOrderAttribute"/>
 /// Имеющийся порядок на данный момент:
 /// ATI.Services.Authorization.AuthorizationInitializer - InitializeOrder.First

--- a/ATI.Services.Common/Initializers/StartupInitializer.cs
+++ b/ATI.Services.Common/Initializers/StartupInitializer.cs
@@ -40,7 +40,11 @@ public class StartupInitializer(IServiceProvider serviceProvider)
             var initializerName = initializer.GetType().Name;
 
             if (initializer.GetType().GetCustomAttributes(typeof(InitializeTimeoutAttribute), false).FirstOrDefault()
-                is not InitializeTimeoutAttribute initTimeoutAttribute)
+                is InitializeTimeoutAttribute initTimeoutAttribute)
+            {
+                await InitWithPolicy(initTimeoutAttribute, initializerName, () => initializer.InitializeAsync());
+            }
+            else
             {
                 try
                 {
@@ -50,11 +54,6 @@ public class StartupInitializer(IServiceProvider serviceProvider)
                 {
                     _logger.ErrorWithObject(e, $"Exception during initializer {initializerName}");
                 }
-            }
-            else
-            {
-                await InitWithPolicy(initTimeoutAttribute, initializerName, () => initializer.InitializeAsync());
-                continue;
             }
 
             Console.WriteLine(initializer.InitEndConsoleMessage());

--- a/ATI.Services.Common/Initializers/StartupInitializer.cs
+++ b/ATI.Services.Common/Initializers/StartupInitializer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using ATI.Services.Common.Initializers.Interfaces;
-using JetBrains.Annotations;
 using NLog;
 
 namespace ATI.Services.Common.Initializers;
@@ -11,7 +10,6 @@ public class StartupInitializer(IServiceProvider serviceProvider)
 {
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
-    [UsedImplicitly]
     public async Task InitializeAsync()
     {
         var initializers =

--- a/ATI.Services.Common/Initializers/StartupInitializer.cs
+++ b/ATI.Services.Common/Initializers/StartupInitializer.cs
@@ -72,7 +72,7 @@ public class StartupInitializer(IServiceProvider serviceProvider)
                                  Policy.Handle<Exception>().WaitAndRetryAsync(
                                      initTimeoutAttribute.Retry,
                                      i => TimeSpan.FromMilliseconds(Math.Min(200 * i, 2000)),
-                                     (exception, i) => _logger.Warn(exception, $"Retry number:{i} for initializer {initializerName}")));
+                                     (exception, _, i, _) => _logger.Warn(exception, $"Retry number:{i} for initializer {initializerName}")));
                 
             var policyResult = await initPolicy.ExecuteAndCaptureAsync(init);
             if(policyResult.Outcome is OutcomeType.Successful)

--- a/ATI.Services.Common/Initializers/StartupInitializer.cs
+++ b/ATI.Services.Common/Initializers/StartupInitializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using ATI.Services.Common.Initializers.Interfaces;
+using JetBrains.Annotations;
 using NLog;
 
 namespace ATI.Services.Common.Initializers;
@@ -10,6 +11,7 @@ public class StartupInitializer(IServiceProvider serviceProvider)
 {
     private readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
+    [UsedImplicitly]
     public async Task InitializeAsync()
     {
         var initializers =
@@ -53,7 +55,6 @@ public class StartupInitializer(IServiceProvider serviceProvider)
                         _logger.Error(message);
                         throw new Exception(message);
                     }
-
                     var timeoutMessage = $"Initializer {initializer.GetType().Name} didn't complete in {initTimeout}, continue in background.";
                     Console.WriteLine(timeoutMessage);
                     _logger.Warn(timeoutMessage);

--- a/ATI.Services.Common/Logging/LoggerExtension.cs
+++ b/ATI.Services.Common/Logging/LoggerExtension.cs
@@ -23,7 +23,7 @@ public static class LoggerExtension
         logger.LogWithObject(LogLevel.Error, ex, logObjects: logObjects);
     }
 
-    public static void ErrorWithObject(this ILogger logger, params object[] logObjects)
+    public static void ErrorWithObject(this ILogger logger, string message, params object[] logObjects)
     {
         logger.LogWithObject(LogLevel.Error, logObjects: logObjects);
     }

--- a/ATI.Services.Common/Logging/LoggerExtension.cs
+++ b/ATI.Services.Common/Logging/LoggerExtension.cs
@@ -25,7 +25,7 @@ public static class LoggerExtension
 
     public static void ErrorWithObject(this ILogger logger, string message, params object[] logObjects)
     {
-        logger.LogWithObject(LogLevel.Error, logObjects: logObjects);
+        logger.LogWithObject(LogLevel.Error, message: message, logObjects: logObjects);
     }
 
     public static void WarnWithObject(this ILogger logger, string message, params object[] logObjects)

--- a/ATI.Services.Common/Logging/LoggerExtension.cs
+++ b/ATI.Services.Common/Logging/LoggerExtension.cs
@@ -12,8 +12,7 @@ namespace ATI.Services.Common.Logging;
 [PublicAPI]
 public static class LoggerExtension
 {
-    public static void ErrorWithObject(this ILogger logger, Exception ex, string message,
-        params object[] logObjects)
+    public static void ErrorWithObject(this ILogger logger, Exception ex, string message, params object[] logObjects)
     {
         logger.LogWithObject(LogLevel.Error, ex, message, logObjects: logObjects);
     }
@@ -26,6 +25,12 @@ public static class LoggerExtension
     public static void ErrorWithObject(this ILogger logger, string message, params object[] logObjects)
     {
         logger.LogWithObject(LogLevel.Error, message: message, logObjects: logObjects);
+    }
+    
+    [Obsolete("Use ErrorWithObject(this ILogger logger, string message, params object[] logObjects) instead")]
+    public static void ErrorWithObject(this ILogger logger, params object[] logObjects)
+    {
+        logger.LogWithObject(LogLevel.Error, logObjects: logObjects);
     }
 
     public static void WarnWithObject(this ILogger logger, string message, params object[] logObjects)


### PR DESCRIPTION
## IInitializer retry and timeout
New attribute `[InitializeTimeout(InitTimeoutSec = 10, Required = false, Retry = 0)]` for IInitializer classes. 
### Examples:

```csharp
// Without attribute there is no retry or timeout. 
// On exception there will be error log, but init continues.
public sealed class ChangeTrackingHelper : IInitializer
```


```csharp
// With default attribute values are: `InitTimeoutSec=10, Retry=0, Required = false`
// On Exception - init continues + error log. On timeout - init continues + log. No retries.
[InitializeTimeout]
public sealed class ChangeTrackingHelper : IInitializer
```

```csharp
// On Exception - init stops + error log. On timeout - init stops + error log. 
// 5 retries(warnlog on retry, error final log).
[InitializeTimeout(InitTimeoutSec = 30, Required = false, Retry = 5)]
public sealed class ChangeTrackingHelper : IInitializer
```


## Error log overload
Logs for this overload added without message or exception, hard to filter them cause all information is in `logContext` field.  
```csharp
.ErrorWithObject(this ILogger logger, params object[] logObjects)
```
Added new overload with message param. Keeped previous one for back compatibility with [obsolete] attribute.
```csharp
.ErrorWithObject(this ILogger logger, string message, params object[] logObjects)
```
